### PR TITLE
Remove auto-dependency to number module

### DIFF
--- a/components/b2500/__init__.py
+++ b/components/b2500/__init__.py
@@ -37,7 +37,7 @@ CONF_ON_WIFI_INFO = "on_wifi_info"
 CONF_ON_FC41D_INFO = "on_fc41d_info"
 CONF_ON_TIMER_INFO = "on_timer_info"
 
-AUTO_LOAD = ["b2500", "binary_sensor", "switch", "number"]
+AUTO_LOAD = ["b2500", "binary_sensor", "switch"]
 MULTI_CONF = 3
 
 b2500_ns = cg.esphome_ns.namespace("b2500")

--- a/components/b2500/b2500_base.cpp
+++ b/components/b2500/b2500_base.cpp
@@ -273,7 +273,7 @@ void B2500ComponentBase::interpret_cell_info() {
 
 void B2500ComponentBase::interpret_runtime_info() {
   auto payload = this->state_->get_runtime_info();
-  // For nor just dump the values
+  // For now just dump the values
   ESP_LOGD(TAG,
            "in1_active: %d, pv_in2_state: %d, in1_power: %d, in2_power: %d, soc: %d, dev_version: %d, "
            "charge_mode: %d, wifi_connected: %d, mqtt_connected: %d, out1_active: %d, out2_active: %d, out1_enabled: "
@@ -288,10 +288,6 @@ void B2500ComponentBase::interpret_runtime_info() {
            payload.discharge_setting.out1_enable, payload.discharge_setting.out2_enable, payload.discharge_threshold,
            payload.dod, payload.remaining_capacity, payload.device_scene, payload.out1_power, payload.out2_power,
            payload.device_region, payload.extern1_connected, payload.extern2_connected, payload.time.hour, payload.time.minute);
-
-  if (this->dod_number_ != nullptr && this->dod_number_->state != payload.dod) {
-    this->dod_number_->publish_state(payload.dod);
-  }
 }
 
 void B2500ComponentBase::dump_config() {

--- a/components/b2500/b2500_base.h
+++ b/components/b2500/b2500_base.h
@@ -5,7 +5,6 @@
 #include <esp_gattc_api.h>
 #include "esphome/core/component.h"
 #include "esphome/components/ble_client/ble_client.h"
-#include "esphome/components/number/number.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/time/real_time_clock.h"
 
@@ -23,8 +22,6 @@ static const esp32_ble_tracker::ESPBTUUID B2500_COMMAND_UUID =
     esp32_ble_tracker::ESPBTUUID::from_raw("0000ff01-0000-1000-8000-00805f9b34fb");
 
 class B2500ComponentBase : public PollingComponent, public ble_client::BLEClientNode {
-  SUB_NUMBER(dod)
-
  public:
   B2500ComponentBase(int generation);
 

--- a/components/b2500/b2500_v1.cpp
+++ b/components/b2500/b2500_v1.cpp
@@ -72,10 +72,6 @@ void B2500ComponentV1::interpret_message(B2500Message message) {
     if (this->out2_switch_ != nullptr && this->out2_switch_->state != runtime_info.discharge_setting.out2_enable) {
       this->out2_switch_->publish_state(runtime_info.discharge_setting.out2_enable);
     }
-    if (this->discharge_threshold_number_ != nullptr &&
-        this->discharge_threshold_number_->state != runtime_info.discharge_threshold) {
-      this->discharge_threshold_number_->publish_state(runtime_info.discharge_threshold);
-    }
   }
 }
 

--- a/components/b2500/b2500_v1.h
+++ b/components/b2500/b2500_v1.h
@@ -8,7 +8,6 @@ namespace esphome {
 namespace b2500 {
 
 class B2500ComponentV1 : public B2500ComponentBase {
-  SUB_NUMBER(discharge_threshold)
   SUB_SWITCH(out1)
   SUB_SWITCH(out2)
 

--- a/components/b2500/b2500_v2.cpp
+++ b/components/b2500/b2500_v2.cpp
@@ -117,10 +117,6 @@ void B2500ComponentV2::interpret_message(B2500Message message) {
           this->timer_enabled_switch_[i]->state != timer.enabled) {
         this->timer_enabled_switch_[i]->publish_state(timer.enabled);
       }
-      if (this->timer_output_power_number_[i] != nullptr &&
-          this->timer_output_power_number_[i]->state != timer.output_power) {
-        this->timer_output_power_number_[i]->publish_state(timer.output_power);
-      }
     }
     auto timers = this->state_->get_timer_info();
     if (this->adaptive_mode_switch_ != nullptr &&

--- a/components/b2500/b2500_v2.h
+++ b/components/b2500/b2500_v2.h
@@ -15,9 +15,6 @@ class B2500ComponentV2 : public B2500ComponentBase {
 
   void set_timer_enabled_switch(int timer, switch_::Switch *switch_) { this->timer_enabled_switch_[timer] = switch_; }
   void set_adaptive_mode_switch(switch_::Switch *switch_) { this->adaptive_mode_switch_ = switch_; }
-  void set_timer_output_power_number(int timer, number::Number *number) {
-    this->timer_output_power_number_[timer] = number;
-  }
   std::string get_charge_mode() override;
 
   // Actions
@@ -33,8 +30,6 @@ class B2500ComponentV2 : public B2500ComponentBase {
  protected:
   switch_::Switch *timer_enabled_switch_[5]{nullptr};
   switch_::Switch *adaptive_mode_switch_{nullptr};
-
-  number::Number *timer_output_power_number_[5]{nullptr};
 
   void poll_runtime_info_() override;
   void interpret_message(B2500Message message) override;

--- a/components/b2500/number/__init__.py
+++ b/components/b2500/number/__init__.py
@@ -18,11 +18,13 @@ CONF_DISCHARGE_THRESHOLD = "discharge_threshold"
 CONF_DOD = "dod"
 
 DischargeThresholdNumber = b2500_ns.class_(
-    "DischargeThresholdNumber", number.Number, cg.Parented
+    "DischargeThresholdNumber", number.Number, cg.Component, cg.Parented
 )
-DodNumber = b2500_ns.class_("DodNumber", number.Number)
+DodNumber = b2500_ns.class_(
+    "DodNumber", number.Number, cg.Component, cg.Parented
+)
 TimerOutputPowerNumber = b2500_ns.class_(
-    "TimerOutputPowerNumber", number.Number, cg.Parented
+    "TimerOutputPowerNumber", number.Number, cg.Component, cg.Parented
 )
 
 BASE_SCHEMA = cv.Schema(
@@ -79,7 +81,6 @@ NUMBER_ATTRS = {
 
 
 async def to_code(config):
-    b2500_component = await cg.get_variable(config[CONF_B2500_ID])
     for switch_type in [
         CONF_DISCHARGE_THRESHOLD,
         CONF_DOD,
@@ -89,7 +90,7 @@ async def to_code(config):
             args = []
             btn = await number.new_number(conf, *args, **number_attrs)
             await cg.register_parented(btn, config[CONF_B2500_ID])
-            cg.add(getattr(b2500_component, f"set_{switch_type}_number")(btn))
+            await cg.register_component(btn, config)
 
     for x in range(5):
         switch_type = f"timer{x + 1}_output_power"
@@ -100,4 +101,4 @@ async def to_code(config):
                 conf, *args, min_value=50, max_value=800, step=1
             )
             await cg.register_parented(btn, config[CONF_B2500_ID])
-            cg.add(b2500_component.set_timer_output_power_number(x, btn))
+            await cg.register_component(btn, config)

--- a/components/b2500/number/discharge_threshold.cpp
+++ b/components/b2500/number/discharge_threshold.cpp
@@ -1,7 +1,19 @@
 #include "discharge_threshold.h"
+#include "../b2500_state.h"
 
 namespace esphome {
 namespace b2500 {
+
+void DischargeThresholdNumber::setup() {
+  this->parent_->get_state()->add_on_message_callback([this](B2500Message message) {
+    if (message == B2500_MSG_RUNTIME_INFO) {
+      auto runtime_info = this->parent_->get_state()->get_runtime_info();
+      if (this->state != runtime_info.discharge_threshold) {
+        this->publish_state(runtime_info.discharge_threshold);
+      }
+    }
+  });
+}
 
 void DischargeThresholdNumber::control(float value) {
   this->parent_->set_discharge_threshold(value);

--- a/components/b2500/number/discharge_threshold.h
+++ b/components/b2500/number/discharge_threshold.h
@@ -6,7 +6,10 @@
 namespace esphome {
 namespace b2500 {
 
-class DischargeThresholdNumber : public number::Number, public Parented<B2500ComponentV1> {
+class DischargeThresholdNumber : public Component, public number::Number, public Parented<B2500ComponentV1> {
+ public:
+  void setup() override;
+
  protected:
   void control(float value) override;
 };

--- a/components/b2500/number/dod.cpp
+++ b/components/b2500/number/dod.cpp
@@ -1,7 +1,19 @@
 #include "dod.h"
+#include "../b2500_state.h"
 
 namespace esphome {
 namespace b2500 {
+
+void DodNumber::setup() {
+  this->parent_->get_state()->add_on_message_callback([this](B2500Message message) {
+    if (message == B2500_MSG_RUNTIME_INFO) {
+      auto runtime_info = this->parent_->get_state()->get_runtime_info();
+      if (this->state != runtime_info.dod) {
+        this->publish_state(runtime_info.dod);
+      }
+    }
+  });
+}
 
 void DodNumber::control(float value) {
   this->parent_->set_dod(value);

--- a/components/b2500/number/dod.h
+++ b/components/b2500/number/dod.h
@@ -6,7 +6,10 @@
 namespace esphome {
 namespace b2500 {
 
-class DodNumber : public number::Number, public Parented<B2500ComponentBase> {
+class DodNumber : public Component, public number::Number, public Parented<B2500ComponentBase> {
+ public:
+  void setup() override;
+
  protected:
   void control(float value) override;
 };

--- a/components/b2500/number/timer_output_power.cpp
+++ b/components/b2500/number/timer_output_power.cpp
@@ -1,7 +1,19 @@
 #include "timer_output_power.h"
+#include "../b2500_state.h"
 
 namespace esphome {
 namespace b2500 {
+
+void TimerOutputPowerNumber::setup() {
+  this->parent_->get_state()->add_on_message_callback([this](B2500Message message) {
+    if (message == B2500_MSG_TIMER_INFO) {
+      auto timer = this->parent_->get_state()->get_timer(this->timer_);
+      if (this->state != timer.output_power) {
+        this->publish_state(timer.output_power);
+      }
+    }
+  });
+}
 
 void TimerOutputPowerNumber::control(float value) {
   this->parent_->set_timer_output_power(this->timer_, value);

--- a/components/b2500/number/timer_output_power.h
+++ b/components/b2500/number/timer_output_power.h
@@ -6,9 +6,10 @@
 namespace esphome {
 namespace b2500 {
 
-class TimerOutputPowerNumber : public number::Number, public Parented<B2500ComponentV2> {
+class TimerOutputPowerNumber : public Component, public number::Number, public Parented<B2500ComponentV2> {
  public:
   TimerOutputPowerNumber(int timer) : timer_(timer) {}
+  void setup() override;
 
  protected:
   void control(float value) override;


### PR DESCRIPTION
This lets the number-components register themselves to updates rather than registering the component directly in the B2500 component, allowing the number module to be omitted from the build when not used.