### PR TITLE
Remove auto-dependency to switch module

### DIFF
--- a/components/b2500/__init__.py
+++ b/components/b2500/__init__.py
@@ -37,7 +37,7 @@ CONF_ON_WIFI_INFO = "on_wifi_info"
 CONF_ON_FC41D_INFO = "on_fc41d_info"
 CONF_ON_TIMER_INFO = "on_timer_info"
 
-AUTO_LOAD = ["b2500", "binary_sensor", "switch"]
+AUTO_LOAD = ["b2500", "binary_sensor"]
 MULTI_CONF = 3
 
 b2500_ns = cg.esphome_ns.namespace("b2500")

--- a/components/b2500/b2500_base.h
+++ b/components/b2500/b2500_base.h
@@ -5,7 +5,6 @@
 #include <esp_gattc_api.h>
 #include "esphome/core/component.h"
 #include "esphome/components/ble_client/ble_client.h"
-#include "esphome/components/switch/switch.h"
 #include "esphome/components/time/real_time_clock.h"
 
 #include "b2500_state.h"

--- a/components/b2500/b2500_v1.cpp
+++ b/components/b2500/b2500_v1.cpp
@@ -62,19 +62,6 @@ std::string B2500ComponentV1::get_charge_mode() {
   }
 }
 
-void B2500ComponentV1::interpret_message(B2500Message message) {
-  B2500ComponentBase::interpret_message(message);
-  if (message == B2500_MSG_RUNTIME_INFO) {
-    auto runtime_info = this->state_->get_runtime_info();
-    if (this->out1_switch_ != nullptr && this->out1_switch_->state != runtime_info.discharge_setting.out1_enable) {
-      this->out1_switch_->publish_state(runtime_info.discharge_setting.out1_enable);
-    }
-    if (this->out2_switch_ != nullptr && this->out2_switch_->state != runtime_info.discharge_setting.out2_enable) {
-      this->out2_switch_->publish_state(runtime_info.discharge_setting.out2_enable);
-    }
-  }
-}
-
 }  // namespace b2500
 }  // namespace esphome
 #endif  // USE_ESP32

--- a/components/b2500/b2500_v1.h
+++ b/components/b2500/b2500_v1.h
@@ -8,9 +8,6 @@ namespace esphome {
 namespace b2500 {
 
 class B2500ComponentV1 : public B2500ComponentBase {
-  SUB_SWITCH(out1)
-  SUB_SWITCH(out2)
-
  public:
   B2500ComponentV1() : B2500ComponentBase(1) {}
 
@@ -21,9 +18,6 @@ class B2500ComponentV1 : public B2500ComponentBase {
   bool set_out_active(int out, bool active);
   bool set_discharge_threshold(float threshold);
   bool set_charge_mode(const std::string &charge_mode) override;
-
- protected:
-  void interpret_message(B2500Message message) override;
 };
 
 }  // namespace b2500

--- a/components/b2500/b2500_v2.cpp
+++ b/components/b2500/b2500_v2.cpp
@@ -108,24 +108,6 @@ bool B2500ComponentV2::set_adaptive_mode_enabled(bool enabled) {
   return true;
 }
 
-void B2500ComponentV2::interpret_message(B2500Message message) {
-  B2500ComponentBase::interpret_message(message);
-  if (message == B2500_MSG_TIMER_INFO) {
-    for (int i = 0; i < this->state_->get_number_of_timers(); i++) {
-      auto timer = this->state_->get_timer(i);
-      if (this->timer_enabled_switch_[i] != nullptr &&
-          this->timer_enabled_switch_[i]->state != timer.enabled) {
-        this->timer_enabled_switch_[i]->publish_state(timer.enabled);
-      }
-    }
-    auto timers = this->state_->get_timer_info();
-    if (this->adaptive_mode_switch_ != nullptr &&
-        this->adaptive_mode_switch_->state != timers.base.adaptive_mode_enabled) {
-      this->adaptive_mode_switch_->publish_state(timers.base.adaptive_mode_enabled);
-    }
-  }
-}
-
 }  // namespace b2500
 }  // namespace esphome
 #endif  // USE_ESP32

--- a/components/b2500/b2500_v2.h
+++ b/components/b2500/b2500_v2.h
@@ -13,8 +13,6 @@ class B2500ComponentV2 : public B2500ComponentBase {
 
   std::vector<std::string> get_valid_charge_modes() override;
 
-  void set_timer_enabled_switch(int timer, switch_::Switch *switch_) { this->timer_enabled_switch_[timer] = switch_; }
-  void set_adaptive_mode_switch(switch_::Switch *switch_) { this->adaptive_mode_switch_ = switch_; }
   std::string get_charge_mode() override;
 
   // Actions
@@ -28,11 +26,7 @@ class B2500ComponentV2 : public B2500ComponentBase {
   bool set_adaptive_mode_enabled(bool enabled);
 
  protected:
-  switch_::Switch *timer_enabled_switch_[5]{nullptr};
-  switch_::Switch *adaptive_mode_switch_{nullptr};
-
   void poll_runtime_info_() override;
-  void interpret_message(B2500Message message) override;
 };
 
 }  // namespace b2500

--- a/components/b2500/switch/__init__.py
+++ b/components/b2500/switch/__init__.py
@@ -14,9 +14,9 @@ from .. import (
 DEPENDENCIES = ["b2500"]
 CODEOWNERS = ["@tomquist"]
 
-OutActiveSwitch = b2500_ns.class_("OutActiveSwitch", switch.Switch)
-TimerEnabledSwitch = b2500_ns.class_("TimerEnabledSwitch", switch.Switch)
-AdaptiveModeSwitch = b2500_ns.class_("AdaptiveModeSwitch", switch.Switch)
+OutActiveSwitch = b2500_ns.class_("OutActiveSwitch", switch.Switch, cg.Component, cg.Parented)
+TimerEnabledSwitch = b2500_ns.class_("TimerEnabledSwitch", switch.Switch, cg.Component, cg.Parented)
+AdaptiveModeSwitch = b2500_ns.class_("AdaptiveModeSwitch", switch.Switch, cg.Component, cg.Parented)
 
 
 CONF_ADAPTIVE_MODE = "adaptive_mode"
@@ -67,20 +67,19 @@ CONFIG_SCHEMA = cv.Any(
 
 
 async def to_code(config):
-    b2500_component = await cg.get_variable(config[CONF_B2500_ID])
     if conf := config.get(CONF_ADAPTIVE_MODE):
         btn = await switch.new_switch(conf)
         await cg.register_parented(btn, config[CONF_B2500_ID])
-        cg.add(b2500_component.set_adaptive_mode_switch(btn))
+        await cg.register_component(btn, config)
     for x in range(2):
         switch_type = f"out{x + 1}"
         if conf := config.get(switch_type):
             btn = await switch.new_switch(conf, x)
             await cg.register_parented(btn, config[CONF_B2500_ID])
-            cg.add(getattr(b2500_component, f"set_{switch_type}_switch")(btn))
+            await cg.register_component(btn, config)
     for x in range(5):
         switch_type = f"timer{x + 1}_enabled"
         if conf := config.get(switch_type):
             btn = await switch.new_switch(conf, x)
             await cg.register_parented(btn, config[CONF_B2500_ID])
-            cg.add(b2500_component.set_timer_enabled_switch(x, btn))
+            await cg.register_component(btn, config)

--- a/components/b2500/switch/adaptive_mode_switch.cpp
+++ b/components/b2500/switch/adaptive_mode_switch.cpp
@@ -1,7 +1,19 @@
 #include "adaptive_mode_switch.h"
+#include "../b2500_state.h"
 
 namespace esphome {
 namespace b2500 {
+
+void AdaptiveModeSwitch::setup() {
+  this->parent_->get_state()->add_on_message_callback([this](B2500Message message) {
+    if (message == B2500_MSG_TIMER_INFO) {
+      auto timer_info = this->parent_->get_state()->get_timer_info();
+      if (this->state != timer_info.base.adaptive_mode_enabled) {
+        this->publish_state(timer_info.base.adaptive_mode_enabled);
+      }
+    }
+  });
+}
 
 void AdaptiveModeSwitch::write_state(bool state) {
   if (this->parent_->set_adaptive_mode_enabled(state)) {

--- a/components/b2500/switch/adaptive_mode_switch.h
+++ b/components/b2500/switch/adaptive_mode_switch.h
@@ -6,11 +6,12 @@
 namespace esphome {
 namespace b2500 {
 
-class AdaptiveModeSwitch : public switch_::Switch, public Parented<B2500ComponentV2> {
+class AdaptiveModeSwitch : public Component, public switch_::Switch, public Parented<B2500ComponentV2> {
+ public:
+  void setup() override;
+
  protected:
   void write_state(bool state) override;
-
-  int timer_{0};
 };
 
 }  // namespace b2500

--- a/components/b2500/switch/out_active_switch.cpp
+++ b/components/b2500/switch/out_active_switch.cpp
@@ -1,9 +1,23 @@
 #include "out_active_switch.h"
+#include "../b2500_state.h"
 
 namespace esphome {
 namespace b2500 {
 
 OutActiveSwitch::OutActiveSwitch(int out) : out_(out) {}
+
+void OutActiveSwitch::setup() {
+  this->parent_->get_state()->add_on_message_callback([this](B2500Message message) {
+    if (message == B2500_MSG_RUNTIME_INFO) {
+      auto runtime_info = this->parent_->get_state()->get_runtime_info();
+      bool out_enable = this->out_ == 0 ? runtime_info.discharge_setting.out1_enable : runtime_info.discharge_setting.out2_enable;
+      if (this->state != out_enable) {
+        this->publish_state(out_enable);
+      }
+    }
+  });
+}
+
 void OutActiveSwitch::write_state(bool state) {
   if (this->parent_->set_out_active(out_, state)) {
     this->publish_state(state);

--- a/components/b2500/switch/out_active_switch.h
+++ b/components/b2500/switch/out_active_switch.h
@@ -6,14 +6,15 @@
 namespace esphome {
 namespace b2500 {
 
-class OutActiveSwitch : public switch_::Switch, public Parented<B2500ComponentV1> {
+class OutActiveSwitch : public Component, public switch_::Switch, public Parented<B2500ComponentV1> {
  public:
   OutActiveSwitch(int out);
+  void setup() override;
 
  protected:
   void write_state(bool state) override;
 
-  int out_{0};
+  int out_;
 };
 
 }  // namespace b2500

--- a/components/b2500/switch/timer_enabled_switch.cpp
+++ b/components/b2500/switch/timer_enabled_switch.cpp
@@ -1,9 +1,22 @@
 #include "timer_enabled_switch.h"
+#include "../b2500_state.h"
 
 namespace esphome {
 namespace b2500 {
 
 TimerEnabledSwitch::TimerEnabledSwitch(int timer) : timer_(timer) {}
+
+void TimerEnabledSwitch::setup() {
+  this->parent_->get_state()->add_on_message_callback([this](B2500Message message) {
+    if (message == B2500_MSG_TIMER_INFO) {
+      auto timer = this->parent_->get_state()->get_timer(this->timer_);
+      if (this->state != timer.enabled) {
+        this->publish_state(timer.enabled);
+      }
+    }
+  });
+}
+
 void TimerEnabledSwitch::write_state(bool state) {
   if (this->parent_->set_timer_enabled(this->timer_, state)) {
     this->publish_state(state);

--- a/components/b2500/switch/timer_enabled_switch.h
+++ b/components/b2500/switch/timer_enabled_switch.h
@@ -6,14 +6,15 @@
 namespace esphome {
 namespace b2500 {
 
-class TimerEnabledSwitch : public switch_::Switch, public Parented<B2500ComponentV2> {
+class TimerEnabledSwitch : public Component, public switch_::Switch, public Parented<B2500ComponentV2> {
  public:
   TimerEnabledSwitch(int timer);
+  void setup() override;
 
  protected:
   void write_state(bool state) override;
 
-  int timer_{0};
+  int timer_;
 };
 
 }  // namespace b2500


### PR DESCRIPTION
This lets the switch-components register themselves to updates rather than registering the component directly in the B2500 component, allowing the switch module to be omitted from the build when not used.