### PR TITLE
Fix missing std::queue include

### DIFF
--- a/components/b2500/b2500_base.h
+++ b/components/b2500/b2500_base.h
@@ -7,6 +7,9 @@
 #include "esphome/components/ble_client/ble_client.h"
 #include "esphome/components/time/real_time_clock.h"
 
+#include <queue>
+#include <vector>
+
 #include "b2500_state.h"
 
 namespace esphome {


### PR DESCRIPTION
## Summary
- fix compile error for B2500 component by adding `<queue>` and `<vector>` includes

## Testing
- `npm test` *(fails: react-app-rewired not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6853a30e9b74832ea9abe2275b65403f