### PR TITLE
Fix device limit based on BLE max

### DIFF
--- a/components/b2500/__init__.py
+++ b/components/b2500/__init__.py
@@ -1,7 +1,7 @@
 from esphome import automation
 from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
-from esphome.components import binary_sensor, ble_client, time
+from esphome.components import binary_sensor, ble_client, time, esp32_ble_tracker
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_DATETIME,
@@ -38,7 +38,7 @@ CONF_ON_FC41D_INFO = "on_fc41d_info"
 CONF_ON_TIMER_INFO = "on_timer_info"
 
 AUTO_LOAD = ["b2500"]
-MULTI_CONF = 3
+MULTI_CONF = esp32_ble_tracker.max_connections()
 
 b2500_ns = cg.esphome_ns.namespace("b2500")
 

--- a/src/components/ConfigForm.tsx
+++ b/src/components/ConfigForm.tsx
@@ -26,6 +26,7 @@ import AdvancedSection from './AdvancedSection';
 import { StorageForm } from './StorageForm';
 import { InfoOutlined } from '@mui/icons-material';
 import { templates } from '../templates';
+import { getMaxBleDevices } from '../utils';
 
 interface ConfigFormProps {
   formValues: FormValues;
@@ -305,7 +306,7 @@ const ConfigForm: React.FC<ConfigFormProps> = ({
         templateVersion={formValues.template_version}
         storages={formValues.storages}
         onChange={handleStorageChange}
-        maxStorages={3}
+        maxStorages={getMaxBleDevices()}
         minStorages={1}
       />
     </Paper>

--- a/src/components/StorageForm.tsx
+++ b/src/components/StorageForm.tsx
@@ -1,6 +1,6 @@
 // src/components/StorageForm.tsx
 import React from 'react';
-import { Button, TextField, Box, Typography, Grid } from '@mui/material';
+import { Button, TextField, Box, Typography, Grid, Alert } from '@mui/material';
 import { Storage, TemplateVersion } from '../types';
 import { templates } from '../templates';
 
@@ -182,6 +182,12 @@ const StorageForm: React.FC<StorageFormProps> = ({
           </Box>
         );
       })}
+      {storages.length >= 3 && (
+        <Alert severity="warning" sx={{ mt: 2 }}>
+          Adding more than two devices may cause instabilities due to high
+          resource usage. Proceed at your own risk.
+        </Alert>
+      )}
       {storages.length < maxStorages && (
         <Button variant="contained" color="primary" onClick={handleAddStorage}>
           Add Storage

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -145,6 +145,12 @@ export const redactSecrets = (config: FormValues) => {
   return redactedConfig;
 };
 
+// The maximum number of BLE connections depends on the framework used.
+// ESPHome's esp32_ble_tracker module defines `max_connections()` which
+// returns 9 for ESP-IDF and 3 for Arduino. Since all templates in this
+// project use ESP-IDF by default, we allow up to 9 B2500 devices.
+export const getMaxBleDevices = (): number => 9;
+
 export const validateConfig = (config: FormValues) => {
   const template = templates[config.template_version];
   const errors = [];


### PR DESCRIPTION
## Summary
- import esp32_ble_tracker in the B2500 component
- base MULTI_CONF on esp32_ble_tracker.max_connections()
- expose max BLE device count to the UI and use it for StorageForm

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm test` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f7b036b8832ebdb3a6859537a466