### PR TITLE
Pin CI to ESPHome 2025.6.3

### DIFF
--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -57,7 +57,7 @@ jobs:
         uses: esphome/build-action@v7.0.0
         with:
           yaml-file: device.yaml
-          version: ${{ github.event.client_payload.esphome_version || 'latest' }}
+          version: ${{ github.event.client_payload.esphome_version || '2025.6.3' }}
         continue-on-error: true
 
       - name: Debug on failure

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,6 +80,7 @@ jobs:
         uses: esphome/build-action@v7.0.0
         with:
           yaml-file: device.yaml
+          version: '2025.6.3'
 
       - name: Create zip with password
         run: |


### PR DESCRIPTION
## Summary
- pin `esphome/build-action` default version for manual build workflows
- set the PR workflow build to ESPHome 2025.6.3

## Testing
- `pip install esphome pytest`
- `pytest -q`

Related to #168

------
https://chatgpt.com/codex/tasks/task_e_6878f8546984832eb8f80b0cef22bc3d