### PR TITLE
Use typed_schema for generation selection

### DIFF
--- a/components/b2500/__init__.py
+++ b/components/b2500/__init__.py
@@ -119,24 +119,28 @@ BASE_SCHEMA = (
     .extend(cv.polling_component_schema("10s"))
 )
 
-CONFIG_SCHEMA = cv.Any(
-    cv.Schema(
-        {
-            cv.GenerateID(): cv.declare_id(B2500ComponentV1),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(1),
-        }
-    ).extend(BASE_SCHEMA),
-    cv.Schema(
-        {
-            cv.GenerateID(): cv.declare_id(B2500ComponentV2),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(2),
-            cv.Optional(CONF_ON_TIMER_INFO): automation.validate_automation(
-                {
-                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(TimerInfoTrigger),
-                }
-            ),
-        }
-    ).extend(BASE_SCHEMA),
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        1: cv.Schema(
+            {
+                cv.GenerateID(): cv.declare_id(B2500ComponentV1),
+            }
+        ).extend(BASE_SCHEMA),
+        2: cv.Schema(
+            {
+                cv.GenerateID(): cv.declare_id(B2500ComponentV2),
+                cv.Optional(CONF_ON_TIMER_INFO): automation.validate_automation(
+                    {
+                        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                            TimerInfoTrigger
+                        ),
+                    }
+                ),
+            }
+        ).extend(BASE_SCHEMA),
+    },
+    key=CONF_B2500_GENERATION,
+    int=True,
 )
 
 

--- a/components/b2500/binary_sensor/__init__.py
+++ b/components/b2500/binary_sensor/__init__.py
@@ -56,35 +56,37 @@ BASE_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = cv.Any(
-    cv.Schema(
-        {
-            cv.GenerateID(): cv.declare_id(B2500BinarySensorV1),
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(1),
-            **{
-                cv.Optional(marker): cv.maybe_simple_value(
-                    binary_sensor.binary_sensor_schema(),
-                    key=CONF_NAME,
-                )
-                for marker in V1_MARKERS
-            },
-        }
-    ).extend(BASE_SCHEMA),
-    cv.Schema(
-        {
-            cv.GenerateID(): cv.declare_id(B2500BinarySensorV2),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(2),
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
-            **{
-                cv.Optional(marker): cv.maybe_simple_value(
-                    binary_sensor.binary_sensor_schema(),
-                    key=CONF_NAME,
-                )
-                for marker in V2_MARKERS
-            },
-        }
-    ).extend(BASE_SCHEMA),
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        1: cv.Schema(
+            {
+                cv.GenerateID(): cv.declare_id(B2500BinarySensorV1),
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
+                **{
+                    cv.Optional(marker): cv.maybe_simple_value(
+                        binary_sensor.binary_sensor_schema(),
+                        key=CONF_NAME,
+                    )
+                    for marker in V1_MARKERS
+                },
+            }
+        ).extend(BASE_SCHEMA),
+        2: cv.Schema(
+            {
+                cv.GenerateID(): cv.declare_id(B2500BinarySensorV2),
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
+                **{
+                    cv.Optional(marker): cv.maybe_simple_value(
+                        binary_sensor.binary_sensor_schema(),
+                        key=CONF_NAME,
+                    )
+                    for marker in V2_MARKERS
+                },
+            }
+        ).extend(BASE_SCHEMA),
+    },
+    key=CONF_B2500_GENERATION,
+    int=True,
 )
 
 

--- a/components/b2500/button/__init__.py
+++ b/components/b2500/button/__init__.py
@@ -36,19 +36,21 @@ BASE_SCHEMA = cv.Schema(
         ),
     }
 )
-CONFIG_SCHEMA = cv.Any(
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(1),
-        }
-    ).extend(BASE_SCHEMA),
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(2),
-        }
-    ).extend(BASE_SCHEMA),
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        1: cv.Schema(
+            {
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
+            }
+        ).extend(BASE_SCHEMA),
+        2: cv.Schema(
+            {
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
+            }
+        ).extend(BASE_SCHEMA),
+    },
+    key=CONF_B2500_GENERATION,
+    int=True,
 )
 
 

--- a/components/b2500/number/__init__.py
+++ b/components/b2500/number/__init__.py
@@ -40,38 +40,40 @@ BASE_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = cv.Any(
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(1),
-            cv.Optional(CONF_DISCHARGE_THRESHOLD): cv.maybe_simple_value(
-                number.number_schema(
-                    DischargeThresholdNumber,
-                    unit_of_measurement=UNIT_WATT,
-                    entity_category=ENTITY_CATEGORY_CONFIG,
-                ),
-                key=CONF_NAME,
-            ),
-        }
-    ).extend(BASE_SCHEMA),
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(2),
-            **{
-                cv.Optional(f"timer{x + 1}_output_power"): cv.maybe_simple_value(
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        1: cv.Schema(
+            {
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
+                cv.Optional(CONF_DISCHARGE_THRESHOLD): cv.maybe_simple_value(
                     number.number_schema(
-                        TimerOutputPowerNumber,
+                        DischargeThresholdNumber,
                         unit_of_measurement=UNIT_WATT,
                         entity_category=ENTITY_CATEGORY_CONFIG,
                     ),
                     key=CONF_NAME,
-                )
-                for x in range(5)
-            },
-        }
-    ).extend(BASE_SCHEMA),
+                ),
+            }
+        ).extend(BASE_SCHEMA),
+        2: cv.Schema(
+            {
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
+                **{
+                    cv.Optional(f"timer{x + 1}_output_power"): cv.maybe_simple_value(
+                        number.number_schema(
+                            TimerOutputPowerNumber,
+                            unit_of_measurement=UNIT_WATT,
+                            entity_category=ENTITY_CATEGORY_CONFIG,
+                        ),
+                        key=CONF_NAME,
+                    )
+                    for x in range(5)
+                },
+            }
+        ).extend(BASE_SCHEMA),
+    },
+    key=CONF_B2500_GENERATION,
+    int=True,
 )
 
 NUMBER_ATTRS = {

--- a/components/b2500/select/__init__.py
+++ b/components/b2500/select/__init__.py
@@ -31,19 +31,21 @@ BASE_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = cv.Any(
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(1),
-        }
-    ).extend(BASE_SCHEMA),
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(2),
-        }
-    ).extend(BASE_SCHEMA),
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        1: cv.Schema(
+            {
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
+            }
+        ).extend(BASE_SCHEMA),
+        2: cv.Schema(
+            {
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
+            }
+        ).extend(BASE_SCHEMA),
+    },
+    key=CONF_B2500_GENERATION,
+    int=True,
 )
 
 

--- a/components/b2500/sensor/__init__.py
+++ b/components/b2500/sensor/__init__.py
@@ -185,72 +185,74 @@ BASE_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = cv.Any(
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(1),
-        }
-    ).extend(BASE_SCHEMA),
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(2),
-            cv.Optional(CONF_ADAPTIVE_POWER_OUT): cv.maybe_simple_value(
-                sensor.sensor_schema(
-                    unit_of_measurement=UNIT_WATT,
-                    state_class=STATE_CLASS_MEASUREMENT,
-                    device_class=DEVICE_CLASS_POWER,
-                    accuracy_decimals=0,
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        1: cv.Schema(
+            {
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
+            }
+        ).extend(BASE_SCHEMA),
+        2: cv.Schema(
+            {
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
+                cv.Optional(CONF_ADAPTIVE_POWER_OUT): cv.maybe_simple_value(
+                    sensor.sensor_schema(
+                        unit_of_measurement=UNIT_WATT,
+                        state_class=STATE_CLASS_MEASUREMENT,
+                        device_class=DEVICE_CLASS_POWER,
+                        accuracy_decimals=0,
+                    ),
+                    key=CONF_NAME,
                 ),
-                key=CONF_NAME,
-            ),
-            cv.Optional(CONF_SMART_METER_READING): cv.maybe_simple_value(
-                sensor.sensor_schema(
-                    unit_of_measurement=UNIT_VOLT_AMPS,
-                    state_class=STATE_CLASS_MEASUREMENT,
-                    accuracy_decimals=0,
+                cv.Optional(CONF_SMART_METER_READING): cv.maybe_simple_value(
+                    sensor.sensor_schema(
+                        unit_of_measurement=UNIT_VOLT_AMPS,
+                        state_class=STATE_CLASS_MEASUREMENT,
+                        accuracy_decimals=0,
+                    ),
+                    key=CONF_NAME,
                 ),
-                key=CONF_NAME,
-            ),
-            cv.Optional(CONF_DAILY_TOTAL_BATTERY_CHARGE): cv.maybe_simple_value(
-                sensor.sensor_schema(
-                    unit_of_measurement=UNIT_WATT_HOURS,
-                    state_class=STATE_CLASS_TOTAL_INCREASING,
-                    device_class=DEVICE_CLASS_ENERGY,
-                    accuracy_decimals=0,
+                cv.Optional(CONF_DAILY_TOTAL_BATTERY_CHARGE): cv.maybe_simple_value(
+                    sensor.sensor_schema(
+                        unit_of_measurement=UNIT_WATT_HOURS,
+                        state_class=STATE_CLASS_TOTAL_INCREASING,
+                        device_class=DEVICE_CLASS_ENERGY,
+                        accuracy_decimals=0,
+                    ),
+                    key=CONF_NAME,
                 ),
-                key=CONF_NAME,
-            ),
-            cv.Optional(CONF_DAILY_TOTAL_BATTERY_DISCHARGE): cv.maybe_simple_value(
-                sensor.sensor_schema(
-                    unit_of_measurement=UNIT_WATT_HOURS,
-                    state_class=STATE_CLASS_TOTAL_INCREASING,
-                    device_class=DEVICE_CLASS_ENERGY,
-                    accuracy_decimals=0,
+                cv.Optional(CONF_DAILY_TOTAL_BATTERY_DISCHARGE): cv.maybe_simple_value(
+                    sensor.sensor_schema(
+                        unit_of_measurement=UNIT_WATT_HOURS,
+                        state_class=STATE_CLASS_TOTAL_INCREASING,
+                        device_class=DEVICE_CLASS_ENERGY,
+                        accuracy_decimals=0,
+                    ),
+                    key=CONF_NAME,
                 ),
-                key=CONF_NAME,
-            ),
-            cv.Optional(CONF_DAILY_TOTAL_LOAD_CHARGE): cv.maybe_simple_value(
-                sensor.sensor_schema(
-                    unit_of_measurement=UNIT_WATT_HOURS,
-                    state_class=STATE_CLASS_TOTAL_INCREASING,
-                    device_class=DEVICE_CLASS_ENERGY,
-                    accuracy_decimals=0,
+                cv.Optional(CONF_DAILY_TOTAL_LOAD_CHARGE): cv.maybe_simple_value(
+                    sensor.sensor_schema(
+                        unit_of_measurement=UNIT_WATT_HOURS,
+                        state_class=STATE_CLASS_TOTAL_INCREASING,
+                        device_class=DEVICE_CLASS_ENERGY,
+                        accuracy_decimals=0,
+                    ),
+                    key=CONF_NAME,
                 ),
-                key=CONF_NAME,
-            ),
-            cv.Optional(CONF_DAILY_TOTAL_LOAD_DISCHARGE): cv.maybe_simple_value(
-                sensor.sensor_schema(
-                    unit_of_measurement=UNIT_WATT_HOURS,
-                    state_class=STATE_CLASS_TOTAL_INCREASING,
-                    device_class=DEVICE_CLASS_ENERGY,
-                    accuracy_decimals=0,
+                cv.Optional(CONF_DAILY_TOTAL_LOAD_DISCHARGE): cv.maybe_simple_value(
+                    sensor.sensor_schema(
+                        unit_of_measurement=UNIT_WATT_HOURS,
+                        state_class=STATE_CLASS_TOTAL_INCREASING,
+                        device_class=DEVICE_CLASS_ENERGY,
+                        accuracy_decimals=0,
+                    ),
+                    key=CONF_NAME,
                 ),
-                key=CONF_NAME,
-            ),
-        }
-    ).extend(BASE_SCHEMA),
+            }
+        ).extend(BASE_SCHEMA),
+    },
+    key=CONF_B2500_GENERATION,
+    int=True,
 )
 
 

--- a/components/b2500/switch/__init__.py
+++ b/components/b2500/switch/__init__.py
@@ -23,46 +23,48 @@ CONF_ADAPTIVE_MODE = "adaptive_mode"
 
 BASE_SCHEMA = cv.Schema({})
 
-CONFIG_SCHEMA = cv.Any(
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(1),
-            **{
-                cv.Optional(f"out{x + 1}"): cv.maybe_simple_value(
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        1: cv.Schema(
+            {
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV1),
+                **{
+                    cv.Optional(f"out{x + 1}"): cv.maybe_simple_value(
+                        switch.switch_schema(
+                            OutActiveSwitch,
+                            entity_category=ENTITY_CATEGORY_CONFIG,
+                        ),
+                        key=CONF_NAME,
+                    )
+                    for x in range(2)
+                },
+            }
+        ).extend(BASE_SCHEMA),
+        2: cv.Schema(
+            {
+                cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
+                cv.Optional(CONF_ADAPTIVE_MODE): cv.maybe_simple_value(
                     switch.switch_schema(
-                        OutActiveSwitch,
+                        AdaptiveModeSwitch,
                         entity_category=ENTITY_CATEGORY_CONFIG,
                     ),
                     key=CONF_NAME,
-                )
-                for x in range(2)
-            },
-        }
-    ).extend(BASE_SCHEMA),
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_B2500_ID): cv.use_id(B2500ComponentV2),
-            cv.Required(CONF_B2500_GENERATION): cv.int_(2),
-            cv.Optional(CONF_ADAPTIVE_MODE): cv.maybe_simple_value(
-                switch.switch_schema(
-                    AdaptiveModeSwitch,
-                    entity_category=ENTITY_CATEGORY_CONFIG,
                 ),
-                key=CONF_NAME,
-            ),
-            **{
-                cv.Optional(f"timer{x + 1}_enabled"): cv.maybe_simple_value(
-                    switch.switch_schema(
-                        TimerEnabledSwitch,
-                        entity_category=ENTITY_CATEGORY_CONFIG,
-                    ),
-                    key=CONF_NAME,
-                )
-                for x in range(5)
-            },
-        }
-    ).extend(BASE_SCHEMA),
+                **{
+                    cv.Optional(f"timer{x + 1}_enabled"): cv.maybe_simple_value(
+                        switch.switch_schema(
+                            TimerEnabledSwitch,
+                            entity_category=ENTITY_CATEGORY_CONFIG,
+                        ),
+                        key=CONF_NAME,
+                    )
+                    for x in range(5)
+                },
+            }
+        ).extend(BASE_SCHEMA),
+    },
+    key=CONF_B2500_GENERATION,
+    int=True,
 )
 
 

--- a/components/b2500/text_sensor/__init__.py
+++ b/components/b2500/text_sensor/__init__.py
@@ -41,10 +41,9 @@ MARKERS: dict[str] = [
     CONF_LAST_RESPONSE,
 ]
 
-CONFIG_SCHEMA = B2500_COMPONENT_SCHEMA.extend(
+TEXT_SENSOR_BASE_SCHEMA = B2500_COMPONENT_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(B2500TextSensor),
-        cv.Required(CONF_B2500_GENERATION): cv.int_range(1, 2),
     }
 ).extend(
     {
@@ -54,6 +53,15 @@ CONFIG_SCHEMA = B2500_COMPONENT_SCHEMA.extend(
         )
         for marker in MARKERS
     }
+)
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        1: TEXT_SENSOR_BASE_SCHEMA,
+        2: TEXT_SENSOR_BASE_SCHEMA,
+    },
+    key=CONF_B2500_GENERATION,
+    int=True,
 )
 
 


### PR DESCRIPTION
## Summary
- use `cv.typed_schema` to select schemas based on `generation`
- update component schemas for binary_sensor, button, number, select, sensor, switch, and text_sensor

## Testing
- `pytest -q tests/component_tests/b2500/test_b2500.py`

------
https://chatgpt.com/codex/tasks/task_e_687cdefa3868832ebadc7cf79d49bfa6