### PR TITLE
Fix smart meter reading sign handling

### DIFF
--- a/components/b2500/b2500_codec.h
+++ b/components/b2500/b2500_codec.h
@@ -116,7 +116,7 @@ struct TimerInfo {
 struct SmartMeterInfo {
   uint8_t connected;
   uint16_t power_out;
-  uint16_t meter_reading;
+  int16_t meter_reading;
   uint16_t unknown;
 } __attribute__((packed));
 


### PR DESCRIPTION
## Summary
- interpret smart meter readings as signed values

## Testing
- `pytest tests`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b0296799a4832ebe4fca4b26138f0c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Meter readings now support signed values (negative and positive), improving how values are displayed and calculated.
- Refactor
  - Meter reading values are interpreted as signed 16-bit integers instead of unsigned, preserving size but changing value semantics.
  - Review any calculations, thresholds, or alerts that assumed only non-negative readings.
- Chores
  - Updated data handling to maintain consistency across UI and exports; downstream integrations that parse readings may need verification for signed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->