### PR TITLE
Disable ESP-IDF component manager in ESPHome builds

### DIFF
--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Build firmware
         id: esphome-build
         uses: esphome/build-action@v7.0.0
+        env:
+          IDF_COMPONENT_MANAGER: '0'
         with:
           yaml-file: device.yaml
           version: ${{ github.event.client_payload.esphome_version || '2025.6.3' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,6 +79,8 @@ jobs:
       - name: Build firmware
         id: esphome-build
         uses: esphome/build-action@v7.0.0
+        env:
+          IDF_COMPONENT_MANAGER: '0'
         with:
           yaml-file: device.yaml
           version: ${{ matrix.esphome_version }}


### PR DESCRIPTION
## Summary
- disable the ESP-IDF component manager in the firmware build workflow so ESPHome no longer crashes inside pydantic when running on the latest GitHub runners
- apply the same fix to the pull request matrix builds to keep CI working there as well

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ecef8741f4832eaba766dc8735b762