### PR TITLE
Fix invalid WiFi info package parsing

### DIFF
--- a/components/b2500/b2500_codec.cpp
+++ b/components/b2500/b2500_codec.cpp
@@ -168,19 +168,21 @@ bool B2500Codec::parse_wifi_info(uint8_t *data, uint16_t data_len, WifiInfoPacke
   const char *start = reinterpret_cast<const char *>(data + sizeof(B2500PacketHeader) + 2);
   const char *end = reinterpret_cast<const char *>(data + data_len);
 
-  // Ensure SSID is within a reasonable length
+  // Newer firmware versions may send invalid/empty SSID data, handle gracefully
   if (start >= end) {
-    ESP_LOGW(TAG, "SSID is empty or invalid");
-    return false;
+    ESP_LOGD(TAG, "SSID is empty or invalid (newer firmware may not send SSID)");
+    payload.ssid = "";
+    return true;
   }
 
   // Assign SSID to the payload
   auto ssid = std::string(start, end);
 
-  // Optional: Validate the SSID string (e.g., check for non-printable characters)
+  // Validate the SSID string (e.g., check for non-printable characters)
   if (ssid.empty() || !std::all_of(ssid.begin(), ssid.end(), ::isprint)) {
-    ESP_LOGW(TAG, "SSID contains non-printable characters or is empty");
-    return false;
+    ESP_LOGD(TAG, "SSID contains non-printable characters or is empty (newer firmware may not send SSID)");
+    payload.ssid = "";
+    return true;
   }
 
   payload.ssid = ssid;


### PR DESCRIPTION
Newer firmware versions send wifi info packets with invalid/empty SSID data. Instead of logging warnings on every polling cycle, handle this gracefully by:
- Setting SSID to empty string when invalid
- Downgrading validation warnings to debug level
- Still extracting and using the signal strength value
- Returning success instead of failure

This prevents the cascade of warnings:
- SSID is empty or invalid
- Failed to parse wifi info
- Failed to receive packet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wi‑Fi info parsing to tolerate empty, invalid, or non‑printable SSIDs—reducing failures and improving robustness with newer firmware.

* **Chores**
  * Updated CI workflow version selections to default to the latest and adjusted the set of tested ESPHome versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #111