### PR TITLE
Add sub-device support for storage devices

### DIFF
--- a/src/components/AdvancedSection.tsx
+++ b/src/components/AdvancedSection.tsx
@@ -643,12 +643,23 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({
           label="Use Legacy Entity Names"
           helperText={
             <>
-              When enabled, entity names include the device prefix (e.g.,{' '}
-              <code>B2500 - 1 - Storage: Battery Level</code>). When disabled
-              (default), entity names are simplified (e.g.,{' '}
+              When enabled (default), entity names include the device prefix
+              (e.g., <code>B2500 - 1 - Storage: Battery Level</code>). When
+              disabled, entity names are simplified (e.g.,{' '}
               <code>Battery Level</code>). Device grouping is provided by
-              sub-devices in both cases. Enable this for backward compatibility
-              with existing configurations.
+              sub-devices in both cases.{' '}
+              <b>
+                Note: Simplified names are currently not supported by ESPHome
+                webserver (
+                <a
+                  href="https://github.com/esphome/esphome-webserver/issues/153"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  issue #153
+                </a>
+                ). Keep this enabled until the issue is resolved.
+              </b>
             </>
           }
         />

--- a/src/template_v2.jinja2
+++ b/src/template_v2.jinja2
@@ -45,7 +45,7 @@
 {%- set fallback_hotspot_enable_captive_portal = fallback_hotspot.enable_captive_portal or False %}
 {%- set native_api = native_api or {} %}
 {%- set native_api_enabled = native_api.enabled or False %}
-{%- set use_legacy_entity_names = use_legacy_entity_names if use_legacy_entity_names is defined else false %}
+{%- set use_legacy_entity_names = use_legacy_entity_names if use_legacy_entity_names is defined else true %}
 {%- macro isV2(deviceNr) %}({%- for storage in storages -%}
             {%- if storage.version >= 2 %}ble_device_nr=={{ loop.index }}{% else %}false{% endif %}
             {%- if not loop.last %} || {% endif -%}

--- a/src/template_v2_minimal.jinja2
+++ b/src/template_v2_minimal.jinja2
@@ -42,7 +42,7 @@
 {%- set fallback_hotspot = fallback_hotspot or {} %}
 {%- set fallback_hotspot_ssid = fallback_hotspot.ssid or '' %}
 {%- set fallback_hotspot_enable_captive_portal = fallback_hotspot.enable_captive_portal or False %}
-{%- set use_legacy_entity_names = use_legacy_entity_names if use_legacy_entity_names is defined else false %}
+{%- set use_legacy_entity_names = use_legacy_entity_names if use_legacy_entity_names is defined else true %}
 {%- macro isV2(deviceNr) %}({%- for storage in storages -%}
             {%- if storage.version >= 2 %}ble_device_nr=={{ loop.index }}{% else %}false{% endif %}
             {%- if not loop.last %} || {% endif -%}

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,7 +156,8 @@ export interface FormValues {
   /**
    * Use legacy entity names with device prefix (e.g., "B2500 - 1 - Storage: Battery Level")
    * instead of simplified names (e.g., "Battery Level").
-   * Defaults to false. Enable for backward compatibility with existing configurations.
+   * Defaults to true. Simplified names are currently not supported by ESPHome webserver.
+   * See: https://github.com/esphome/esphome-webserver/issues/153
    */
   use_legacy_entity_names: boolean;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -85,7 +85,7 @@ export const defaultFormValues: FormValues = {
     enabled: false,
   },
   enable_dio_flash_mode: false,
-  use_legacy_entity_names: false,
+  use_legacy_entity_names: true,
   storages: [{ name: 'B2500', version: 1, mac_address: '00:00:00:00:00:00' }],
 };
 


### PR DESCRIPTION
This change implements ESPHome sub-device support (introduced in
ESPHome 2025.7.0) to organize each B2500 storage as a separate
logical device in Home Assistant.

Changes:
- Add devices section to esphome config defining one device per storage
- Add device_id parameter to all storage-specific entities in both
  template_v2.jinja2 and template_v2_minimal.jinja2
- Each storage's entities (sensors, buttons, switches, etc.) now
  reference their corresponding sub-device via device_id

Benefits:
- Each B2500 storage appears as a separate device in Home Assistant
- Better organization when managing multiple battery storage units
- Entities are automatically grouped by their physical storage device
- Cleaner area assignment and device management in Home Assistant

Affected entity types:
- Buttons (reboot, factory reset, WiFi/MQTT config)
- Datetime entities (timer start/end times for v2)
- Number entities (DoD, discharge threshold, timer power)
- Switches (Bluetooth, output control, timer enable, adaptive mode)
- Select entities (charge mode)
- Text sensors (device info, firmware, WiFi SSID, etc.)
- Binary sensors (WiFi/MQTT/BLE connection status, PV/output active)
- Sensors (power, SOC, capacity, temperature, energy totals)

This is a non-breaking change - existing configurations will continue
to work, with entities now properly organized under sub-devices.

Refs: https://esphome.io/components/esphome/#sub-devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Use Legacy Entity Names" toggle (default: enabled) to preserve device-prefixed entity names; disabling opts into simplified names (note: simplified names not yet supported by the ESPHome webserver).
  * Introduced per-storage device associations in generated Home Assistant/ESPHome configurations so each storage-related entity is linked to its corresponding device for clearer device scoping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->