### PR TITLE
Add `automated_build` flag to toggle web_server JS include for automated builds

### DIFF
--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -18,6 +18,7 @@ jobs:
       PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
       S3_BUCKET: esphome-b2500-images
       AWS_REGION: eu-west-1
+      AUTOMATED_BUILD: 'true'
     permissions:
       contents: write
     steps:

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -19,7 +19,8 @@ const configJSON = Buffer.concat([
 
 nunjucks
   .configure({ autoescape: false })
-  .addGlobal('git_sha', process.env.GITHUB_SHA);
+  .addGlobal('git_sha', process.env.GITHUB_SHA)
+  .addGlobal('automated_build', process.env.AUTOMATED_BUILD === 'true');
 const { config, secrets } = JSON.parse(configJSON);
 
 // Mask all secrets

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import PublishOutlinedIcon from '@mui/icons-material/PublishOutlined';
 import { useMediaQuery } from '@mui/material';
 import { templates } from './templates';
 
-nunjucks.configure({ autoescape: false });
+nunjucks.configure({ autoescape: false }).addGlobal('automated_build', false);
 
 const theme = createTheme();
 const darkTheme = createTheme({

--- a/src/template.jinja2
+++ b/src/template.jinja2
@@ -42,6 +42,7 @@
 {%- set enable_web_server = enable_web_server or False %}
 {%- set web_server_port = web_server.port or 80 %}
 {%- set web_server_ota = web_server.ota or False %}
+{%- set automated_build = automated_build or false %}
 {%- set web_server_js_include = web_server.js_include or './v2/www.js' %}
 {%- set enable_ota = enable_ota %}
 {%- set ota = ota or {} %}
@@ -220,9 +221,13 @@ wifi:
 web_server:
   port: {{ web_server_port }}
   ota: false
+  {%- if automated_build %}
   js_include: "{{ yaml_string(web_server_js_include) }}"
   js_url: ""
   version: 2
+  {%- else %}
+  version: 3
+  {%- endif %}
 {%- endif %}
 
 {%- if enable_fallback_hotspot and fallback_hotspot_enable_captive_portal %}

--- a/src/template_v2.jinja2
+++ b/src/template_v2.jinja2
@@ -33,6 +33,7 @@
 {%- set enable_web_server = enable_web_server or False %}
 {%- set web_server_port = web_server.port or 80 %}
 {%- set web_server_ota = web_server.ota or False %}
+{%- set automated_build = automated_build or false %}
 {%- set web_server_js_include = web_server.js_include or './v2/www.js' %}
 {%- set enable_ota = enable_ota %}
 {%- set ota = ota or {} %}
@@ -173,9 +174,13 @@ wifi:
 web_server:
   port: {{ web_server_port }}
   ota: false
+  {%- if automated_build %}
   js_include: "{{ yaml_string(web_server_js_include) }}"
   js_url: ""
   version: 2
+  {%- else %}
+  version: 3
+  {%- endif %}
 {%- endif %}
 
 {%- if enable_fallback_hotspot and fallback_hotspot_enable_captive_portal %}


### PR DESCRIPTION
### Motivation
- Frontend-generated configs should not include the legacy `js_include`/`js_url`/`version: 2` web_server block so users who copy the config into their own ESPHome instance can use the newer format.
- The automated GitHub workflow must keep the legacy JS include for image builds that rely on the bundled `www.js` asset.
- Introduce a signal that distinguishes the automated build path from the frontend/local render path to switch which web_server variant is emitted.
- Keep the frontend behavior unchanged for local users while enabling the CI path to opt into the legacy output.

### Description
- Add an `automated_build` Jinja variable and use it in `src/template.jinja2` and `src/template_v2.jinja2` to conditionally emit the legacy `js_include`/`js_url`/`version: 2` block when `automated_build` is true, otherwise emit `version: 3`.
- Default the frontend renderer to non-automated by adding `automated_build = false` as a global in `src/App.tsx` via `nunjucks.addGlobal`.
- Make the render script set the global based on the environment by updating `scripts/render.js` to call `.addGlobal('automated_build', process.env.AUTOMATED_BUILD === 'true')`.
- Inject `AUTOMATED_BUILD: 'true'` into the GitHub Actions job environment in `.github/workflows/build-esphome.yml` so CI renders use the legacy web_server variant.

### Testing
- No automated tests were executed for these changes.
- The change was validated by updating templates and render globals and committing the modifications without running CI builds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d5387240832eab97b3bcca8b7d42)