### PR TITLE
Fix HA duration unit for uptime sensor

### DIFF
--- a/src/template.jinja2
+++ b/src/template.jinja2
@@ -1103,7 +1103,7 @@ sensor:
     name: Uptime Sensor
     filters:
       - lambda: return x / 3600.0;
-    unit_of_measurement: "hours"
+    unit_of_measurement: "h"
     accuracy_decimals: 2
     state_topic: "{{ yaml_string(mqtt_topic) }}/esp32/uptime"
   

--- a/src/template_v2.jinja2
+++ b/src/template_v2.jinja2
@@ -831,7 +831,7 @@ sensor:
     name: Uptime Sensor
     filters:
       - lambda: return x / 3600.0;
-    unit_of_measurement: "hours"
+    unit_of_measurement: "h"
     accuracy_decimals: 2
 {%- if mqtt.enabled %}
     state_topic: "{{ yaml_string(mqtt_topic) }}/esp32/uptime"

--- a/src/template_v2_minimal.jinja2
+++ b/src/template_v2_minimal.jinja2
@@ -692,7 +692,7 @@ sensor:
     name: Uptime Sensor
     filters:
       - lambda: return x / 3600.0;
-    unit_of_measurement: "hours"
+    unit_of_measurement: "h"
     accuracy_decimals: 2
     state_topic: "{{ yaml_string(mqtt_topic) }}/esp32/uptime"
     retain: false


### PR DESCRIPTION
## Summary
- change uptime sensor unit from `"hours"` to `"h"`
- apply the same fix across all templates (`template`, `template_v2`, `template_v2_minimal`)

## Why
Home Assistant `device_class: duration` only accepts units like `d`, `h`, `min`, `s`, `ms`, `µs`.
Using `"hours"` triggers warnings and invalid discovery config.

Fixes #89


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated uptime sensor display unit from "hours" to "h" for brevity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->