### PR TITLE
Fix Smartmeter Value device_class for VA in HA

### DIFF
--- a/src/template.jinja2
+++ b/src/template.jinja2
@@ -1217,7 +1217,7 @@ sensor:
     state_topic: "{{ yaml_string(mqtt_topic) }}/{{ loop.index }}/smartmeter/value"
     accuracy_decimals: 0
     unit_of_measurement: 'VA'
-    device_class: power
+    device_class: apparent_power
     icon: mdi:meter-electric
   {%- endif %}
 

--- a/src/template_v2.jinja2
+++ b/src/template_v2.jinja2
@@ -969,7 +969,7 @@ sensor:
       state_topic: "{{ yaml_string(mqtt_topic) }}/{{ loop.index }}/smartmeter/value"
       retain: false
 {%- endif %}
-      device_class: power
+      device_class: apparent_power
       icon: mdi:meter-electric
     daily_total_battery_charge:
       name: "{{ sensor_prefix(loop.index, storage) }} Daily Total Battery Charge"


### PR DESCRIPTION
## Summary
- change Smartmeter Value sensor `device_class` from `power` to `apparent_power`
- keep unit as `VA`
- apply in both templates:
  - `src/template.jinja2`
  - `src/template_v2.jinja2`

## Why
Home Assistant validates units against `device_class`.
`VA` is valid for `apparent_power`, but invalid for `power` (which expects W/kW/etc).

Fixes #91
