### PR TITLE
Fix deprecated CORE.using_esp_idf check

### DIFF
--- a/components/b2500/__init__.py
+++ b/components/b2500/__init__.py
@@ -53,7 +53,7 @@ def _get_max_connections():
 
         default = getattr(esp32_ble, "DEFAULT_MAX_CONNECTIONS", 1)
         idf = getattr(esp32_ble, "IDF_MAX_CONNECTIONS", default)
-        return idf if CORE.using_esp_idf else default
+        return idf if CORE.is_esp32 else default
 
     # Fallback to a single instance if both helper APIs are unavailable
     return 1


### PR DESCRIPTION
## Summary
- replace deprecated `CORE.using_esp_idf` check in `components/b2500/__init__.py`
- use `CORE.is_esp32` to avoid 2026.1 deprecation warning

## Why
ESPHome 2026.1 warns that `CORE.using_esp_idf` is deprecated and behavior changes in 2026.6.

Fixes #219


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected device detection logic for ESP32 connection configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->