### PR TITLE
b2500: Use integer templatable for `timer` in `set_timer` and add component tests

### DIFF
--- a/components/b2500/__init__.py
+++ b/components/b2500/__init__.py
@@ -456,7 +456,7 @@ async def b2500_set_timer(config, action_id, template_arg, args):
     action_var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(action_var, config[CONF_ID])
 
-    template_ = await cg.templatable(config["timer"], args, cg.std_string)
+    template_ = await cg.templatable(config["timer"], args, cg.int_)
     cg.add(action_var.set_timer(template_))
     if "enabled" in config:
         template_ = await cg.templatable(

--- a/tests/component_tests/b2500/test_b2500.py
+++ b/tests/component_tests/b2500/test_b2500.py
@@ -24,3 +24,19 @@ def test_b2500_component_generation(generate_main, yaml_file: str, expected: str
 
     main_cpp = generate_main(temp_path)
     assert expected in main_cpp
+
+
+def test_b2500_set_timer_generation_uses_integer_templates(generate_main):
+    yaml_path = Path(__file__).with_name("test_b2500_v2_actions.yaml")
+    contents = yaml_path.read_text()
+    component_dir = (Path(__file__).parents[3] / "components").resolve()
+    contents = contents.replace("COMPONENT_PATH", str(component_dir))
+
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        f.write(contents)
+        temp_path = f.name
+
+    main_cpp = generate_main(temp_path)
+
+    assert "set_timer(1)" in main_cpp
+    assert "set_timer([=]() -> int" in main_cpp

--- a/tests/component_tests/b2500/test_b2500.py
+++ b/tests/component_tests/b2500/test_b2500.py
@@ -39,4 +39,7 @@ def test_b2500_set_timer_generation_uses_integer_templates(generate_main):
     main_cpp = generate_main(temp_path)
 
     assert "set_timer(1)" in main_cpp
-    assert "set_timer([=]() -> int" in main_cpp
+    lambda_set_timer = "set_timer([]() -> int {"
+    assert lambda_set_timer in main_cpp
+    lambda_set_timer_index = main_cpp.index(lambda_set_timer)
+    assert "return 2;" in main_cpp[lambda_set_timer_index: lambda_set_timer_index + 200]

--- a/tests/component_tests/b2500/test_b2500_v2_actions.yaml
+++ b/tests/component_tests/b2500/test_b2500_v2_actions.yaml
@@ -1,0 +1,38 @@
+external_components:
+  - source: COMPONENT_PATH
+    refresh: 0s
+
+wifi:
+  ssid: "test"
+  password: "12345678"
+
+esp32:
+  board: esp32dev
+
+ble_client:
+  mac_address: "00:00:00:00:00:00"
+
+b2500:
+  id: b2500_device
+  generation: 2
+
+logger:
+
+esphome:
+  name: test
+  on_boot:
+    then:
+      - b2500.set_timer:
+          id: b2500_device
+          generation: 2
+          timer: 1
+          enabled: true
+      - b2500.set_timer:
+          id: b2500_device
+          generation: 2
+          timer: !lambda 'return 2;'
+          start_hour: !lambda 'return 6;'
+
+time:
+  - platform: sntp
+    id: sntp_time


### PR DESCRIPTION
### Motivation
- Fix a type mismatch where the `timer` templatable was emitted as `cg.std_string` while the C++ action `SetTimerAction` declares `TEMPLATABLE_VALUE(int, timer)`, so code generation should treat `timer` as an integer.

### Description
- Change `components/b2500/__init__.py` in `b2500_set_timer` to call `cg.templatable(config["timer"], args, cg.int_)` instead of using `cg.std_string`.
- Add `tests/component_tests/b2500/test_b2500_v2_actions.yaml` including `b2500.set_timer` actions with both a literal `timer` and a lambda `timer` value.
- Extend `tests/component_tests/b2500/test_b2500.py` with `test_b2500_set_timer_generation_uses_integer_templates` that asserts generated C++ contains `set_timer(1)` and a lambda-style integer template `set_timer([=]() -> int`.
- Confirmed the change matches the C++ declaration in `components/b2500/automation.h` which uses `TEMPLATABLE_VALUE(int, timer)`.

### Testing
- Ran `pytest -q tests/component_tests/b2500/test_b2500.py`, but it failed in this environment with `ModuleNotFoundError: No module named 'esphome'`, so the test assertions could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68f59c584832eb79ff5d1584c1a65)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Timer field templates now use integer typing for more consistent validation and handling.

* **Tests**
  * Added test coverage for v2 action timer behaviors, including integer-template timers and programmatic timer values to ensure correct generation and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->