### PR TITLE
Guard invalid timer indices in b2500 set_timer flow

### DIFF
--- a/components/b2500/automation.h
+++ b/components/b2500/automation.h
@@ -98,14 +98,20 @@ template<typename... Ts> class SetTimerAction : public Action<Ts...>, public Par
 
  public:
   void play(const Ts &... x) override {
-    auto timer = this->parent_->get_state()->get_timer(this->timer_.value(x...));
+    int timer_idx = this->timer_.value(x...);
+    if (timer_idx < 0 || timer_idx >= 5) {
+      ESP_LOGW("b2500.automation", "Invalid timer index %d in set_timer action", timer_idx);
+      return;
+    }
+
+    auto timer = this->parent_->get_state()->get_timer(timer_idx);
     auto enabled = this->enabled_.value_or(x..., timer.enabled).value_or(timer.enabled);
     auto output_power = this->output_power_.value_or(x..., timer.output_power).value_or(timer.output_power);
     auto start_hour = this->start_hour_.value_or(x..., timer.start.hour).value_or(timer.start.hour);
     auto start_minute = this->start_minute_.value_or(x..., timer.start.minute).value_or(timer.start.minute);
     auto end_hour = this->end_hour_.value_or(x..., timer.end.hour).value_or(timer.end.hour);
     auto end_minute = this->end_minute_.value_or(x..., timer.end.minute).value_or(timer.end.minute);
-    this->parent_->set_timer(this->timer_.value(x...), enabled, output_power, start_hour, start_minute, end_hour, end_minute);
+    this->parent_->set_timer(timer_idx, enabled, output_power, start_hour, start_minute, end_hour, end_minute);
   }
 };
 

--- a/components/b2500/b2500_state.cpp
+++ b/components/b2500/b2500_state.cpp
@@ -240,6 +240,10 @@ bool B2500State::get_simple_command(B2500Command command, std::vector<uint8_t> &
 }
 
 const TimerInfo B2500State::get_timer(int timer) const {
+  if (timer < 0 || timer >= 5) {
+    ESP_LOGW(TAG, "Requested invalid timer index %d", timer);
+    return TimerInfo{};
+  }
   if (timer < 3) {
     return this->timer_info_.base.timer[timer];
   } else {

--- a/tests/component_tests/b2500/test_b2500.py
+++ b/tests/component_tests/b2500/test_b2500.py
@@ -24,3 +24,21 @@ def test_b2500_component_generation(generate_main, yaml_file: str, expected: str
 
     main_cpp = generate_main(temp_path)
     assert expected in main_cpp
+
+
+def test_b2500_set_timer_templated_index_guard(generate_main):
+    yaml_path = Path(__file__).with_name("test_b2500_timer_template_guard.yaml")
+    contents = yaml_path.read_text()
+    component_dir = (Path(__file__).parents[3] / "components").resolve()
+    contents = contents.replace("COMPONENT_PATH", str(component_dir))
+
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        f.write(contents)
+        temp_path = f.name
+
+    main_cpp = generate_main(temp_path)
+    assert "return 99;" in main_cpp
+
+    automation_h = (Path(__file__).parents[3] / "components" / "b2500" / "automation.h").read_text()
+    assert "if (timer_idx < 0 || timer_idx >= 5)" in automation_h
+    assert "Invalid timer index %d in set_timer action" in automation_h

--- a/tests/component_tests/b2500/test_b2500_timer_template_guard.yaml
+++ b/tests/component_tests/b2500/test_b2500_timer_template_guard.yaml
@@ -30,6 +30,6 @@ interval:
     then:
       - b2500.set_timer:
           id: battery
-          b2500_generation: 2
+          generation: 2
           timer: !lambda 'return 99;'
           enabled: true

--- a/tests/component_tests/b2500/test_b2500_timer_template_guard.yaml
+++ b/tests/component_tests/b2500/test_b2500_timer_template_guard.yaml
@@ -1,0 +1,35 @@
+external_components:
+  - source: COMPONENT_PATH
+    refresh: 0s
+
+wifi:
+  ssid: "test"
+  password: "12345678"
+
+esp32:
+  board: esp32dev
+
+ble_client:
+  mac_address: "00:00:00:00:00:00"
+
+b2500:
+  id: battery
+  generation: 2
+
+logger:
+
+esphome:
+  name: test
+
+time:
+  - platform: sntp
+    id: sntp_time
+
+interval:
+  - interval: 60s
+    then:
+      - b2500.set_timer:
+          id: battery
+          b2500_generation: 2
+          timer: !lambda 'return 99;'
+          enabled: true


### PR DESCRIPTION
### Motivation
- Prevent templated or otherwise invalid timer indices from being used to index raw timer arrays and causing undefined behavior or crashes. 

### Description
- Update `SetTimerAction::play` in `components/b2500/automation.h` to evaluate the templated timer once into a local `int timer_idx`, validate it against the supported range, log a warning via `ESP_LOGW` and return early if invalid, and use the validated `timer_idx` for `get_timer(...)` and `set_timer(...)` calls. 
- Harden `B2500State::get_timer(int)` in `components/b2500/b2500_state.cpp` with bounds checks that log a warning and return a safe default `TimerInfo{}` when an invalid index is requested. 
- Add a component test `tests/component_tests/b2500/test_b2500_timer_template_guard.yaml` and extend `tests/component_tests/b2500/test_b2500.py` with `test_b2500_set_timer_templated_index_guard` to exercise a templated out-of-range index and assert the templated value is generated and the guard logic is present. 

### Testing
- Ran `python -m py_compile tests/component_tests/b2500/test_b2500.py`, which succeeded. 
- Ran `pytest -q tests/component_tests/b2500/test_b2500.py`, which failed in this environment with `ModuleNotFoundError: No module named 'esphome'` due to missing test infrastructure. 
- Ran `PYTHONPATH=. pytest -q tests/component_tests/b2500/test_b2500.py`, which also failed with the same missing `esphome` module error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b68fab439c832e92bc94afa6296ba8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for timer indices to prevent invalid timer operations; out-of-range values are now safely handled and produce informative warnings.
* **Tests**
  * Added automated tests verifying timer index boundary checks and the safe handling/logging of invalid timer values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->