### PR TITLE
Harden B2500 cell-info parsing and add malformed-input unit test

### DIFF
--- a/components/b2500/b2500_codec.cpp
+++ b/components/b2500/b2500_codec.cpp
@@ -1,5 +1,9 @@
 #include "b2500_codec.h"
+#include <algorithm>
+#include <cctype>
+#include <charconv>
 #include <cstddef>
+#include <cstring>
 
 namespace esphome {
 namespace b2500 {
@@ -98,6 +102,22 @@ bool B2500Codec::is_valid_cell_info(uint8_t *data, uint16_t data_len) {
   }
   const char *start = reinterpret_cast<const char *>(data);
   const char *end = reinterpret_cast<const char *>(data + data_len);
+  const bool has_only_digits_and_underscores =
+      std::all_of(start, end, [](char c) { return std::isdigit(static_cast<unsigned char>(c)) || c == '_'; });
+  if (!has_only_digits_and_underscores) {
+    return false;
+  }
+
+  if (*start == '_' || *(end - 1) == '_') {
+    return false;
+  }
+
+  for (const char *ptr = start; ptr + 1 < end; ptr++) {
+    if (*ptr == '_' && *(ptr + 1) == '_') {
+      return false;
+    }
+  }
+
   return ((std::count(start, end, '_') == 16) || (std::count(start, start + 10, '_') == 3));
 }
 
@@ -126,8 +146,21 @@ bool B2500Codec::parse_cell_info(uint8_t *data, uint16_t data_len, CellInfoPacke
   int i = 0;
 
   while (std::getline(ss, item, '_')) {
-    // Convert the string to an integer
-    int value = std::stoi(item);
+    if (item.empty()) {
+      ESP_LOGW(TAG, "Failed to parse cell info token: empty token");
+      return false;
+    }
+
+    int value = 0;
+    const char *token_start = item.data();
+    const char *token_end = token_start + item.size();
+    const std::from_chars_result parse_result = std::from_chars(token_start, token_end, value);
+
+    if (parse_result.ec != std::errc() || parse_result.ptr != token_end) {
+      ESP_LOGW(TAG, "Failed to parse cell info token '%s'", item.c_str());
+      return false;
+    }
+
     // Assign the value to the corresponding property
     if (i == SOC_INDEX) {
       payload.soc = value;

--- a/tests/unit/test_b2500_cell_info_parser.py
+++ b/tests/unit/test_b2500_cell_info_parser.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+def test_cell_info_parser_handles_malformed_tokens_gracefully():
+    repo_root = Path(__file__).parents[2]
+    codec_cpp = repo_root / "components" / "b2500" / "b2500_codec.cpp"
+
+    gpp = shutil.which("g++")
+    assert gpp is not None, "g++ is required to run parser robustness test"
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        include_dir = tmp / "esphome" / "core"
+        include_dir.mkdir(parents=True)
+
+        (include_dir / "helpers.h").write_text(
+            """
+#pragma once
+#include <cstdint>
+#include <string>
+#include <vector>
+
+inline std::string format_hex_pretty(const uint8_t *, size_t) { return \"\"; }
+""".strip()
+        )
+        (include_dir / "log.h").write_text(
+            """
+#pragma once
+#define ESP_LOGW(tag, fmt, ...) do {} while (0)
+#define ESP_LOGD(tag, fmt, ...) do {} while (0)
+""".strip()
+        )
+
+        harness = tmp / "cell_info_parser_harness.cpp"
+        harness.write_text(
+            f"""
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+#include \"{(repo_root / 'components' / 'b2500' / 'b2500_codec.h').as_posix()}\"
+
+using esphome::b2500::B2500Codec;
+using esphome::b2500::CellInfoPacket;
+
+bool parse(B2500Codec &codec, const std::string &payload) {{
+  CellInfoPacket packet{{}};
+  auto *data = reinterpret_cast<uint8_t *>(const_cast<char *>(payload.data()));
+  return codec.parse_cell_info(data, static_cast<uint16_t>(payload.size()), packet);
+}}
+
+int main() {{
+  B2500Codec codec;
+
+  const std::string valid = "10_24_25_3162_3161_3156_3156_3152_3162_3156_3156_3151_3153_3153_3153_3147_3155";
+  if (!parse(codec, valid)) {{
+    std::cerr << "expected valid payload to parse" << std::endl;
+    return 1;
+  }}
+
+  const std::vector<std::string> invalid = {{
+      "10_24_25_3162_3161_3156_3156_3152_3162_3156_3156_3151_3153_3153_3153_3147_bad",
+      "10_24_25_3162_3161_3156_3156_3152_3162_3156_3156_3151_3153_3153_3153_3147_",
+      "10_24_25_3162_3161_3156_3156_3152_3162_3156_3156_3151_3153_3153_3153_3147_31 55",
+  }};
+
+  for (const auto &token : invalid) {{
+    if (parse(codec, token)) {{
+      std::cerr << "expected malformed payload to fail: " << token << std::endl;
+      return 2;
+    }}
+  }}
+
+  return 0;
+}}
+""".strip()
+        )
+
+        output = tmp / "cell_info_parser_harness"
+        compile_cmd = [
+            gpp,
+            "-std=c++17",
+            "-I",
+            tmp.as_posix(),
+            "-I",
+            repo_root.as_posix(),
+            harness.as_posix(),
+            codec_cpp.as_posix(),
+            "-o",
+            output.as_posix(),
+        ]
+        subprocess.run(compile_cmd, check=True, capture_output=True, text=True)
+
+        subprocess.run([output.as_posix()], check=True, capture_output=True, text=True)


### PR DESCRIPTION
### Motivation
- Prevent unhandled conversion failures when parsing cell-info payloads by validating tokens before numeric conversion and failing gracefully on malformed input.
- Reduce false-positive candidates early by tightening the heuristic that accepts cell-info strings.

### Description
- Replace `std::stoi` usage in `B2500Codec::parse_cell_info()` with `std::from_chars` and explicit parse-result checks, and log a warning then return `false` on parse failure instead of allowing exceptions or undefined behavior (`components/b2500/b2500_codec.cpp`).
- Tighten `B2500Codec::is_valid_cell_info()` to require only digits and underscores and to reject leading, trailing, or consecutive underscores, reducing malformed candidates before conversion (`components/b2500/b2500_codec.cpp`).
- Add sturdier includes (`<algorithm>`, `<cctype>`, `<charconv>`, `<cstring>`) required by the new logic to make standalone compilation more robust (`components/b2500/b2500_codec.cpp`).
- Add a parser-focused unit test that compiles a small C++ harness against `b2500_codec.cpp` and verifies one valid payload parses while several malformed payloads fail gracefully (`tests/unit/test_b2500_cell_info_parser.py`).

### Testing
- Ran `pytest -q tests/unit/test_b2500_cell_info_parser.py`, which compiles the harness and executes it; the test passed.
- Attempted to run component-level tests (`tests/component_tests/...`) but these failed to import the `esphome` Python package in the current environment, so those higher-level tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b69073a5a0832e82f1feca39e49515)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation with stricter rules for cell info processing
  * Enhanced error detection and logging for parsing failures

* **Tests**
  * Added test coverage for malformed input handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->