### PR TITLE
Fix ESPHome 2026.3.0 build break + action registration warnings

### DIFF
--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -63,7 +63,7 @@ jobs:
         uses: esphome/build-action@v7.1.0
         with:
           yaml-file: device.yaml
-          version: ${{ github.event.client_payload.esphome_version || '2025.12.4' }}
+          version: ${{ github.event.client_payload.esphome_version || '2026.3.0' }}
         continue-on-error: true
 
       - name: Debug on failure

--- a/components/b2500/__init__.py
+++ b/components/b2500/__init__.py
@@ -1,3 +1,5 @@
+import inspect
+
 from esphome import automation
 from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
@@ -42,6 +44,17 @@ CONF_ON_FC41D_INFO = "on_fc41d_info"
 CONF_ON_TIMER_INFO = "on_timer_info"
 
 AUTO_LOAD = ["b2500", "select"]
+
+_REGISTER_ACTION_SUPPORTS_SYNCHRONOUS = (
+    "synchronous" in inspect.signature(automation.register_action).parameters
+)
+
+
+def register_action_compat(action_name, action_type, schema, *, synchronous=True):
+    kwargs = {}
+    if _REGISTER_ACTION_SUPPORTS_SYNCHRONOUS:
+        kwargs["synchronous"] = synchronous
+    return automation.register_action(action_name, action_type, schema, **kwargs)
 
 
 def _get_max_connections():
@@ -204,7 +217,7 @@ B2500_BASE_ACTION_SCHEMA = maybe_simple_id(
 )
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.set_wifi",
     SetWifiAction,
     cv.Schema(
@@ -230,7 +243,7 @@ async def b2500_set_wifi(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.set_mqtt",
     SetMqttAction,
     cv.Schema(
@@ -266,7 +279,7 @@ async def b2500_set_mqtt(config, action_id, template_arg, args):
     cg.add(var.set_password(template_))
     return var
 
-@automation.register_action(
+@register_action_compat(
     "b2500.reset_mqtt",
     ResetMqttAction,
     cv.Schema(
@@ -282,7 +295,7 @@ async def b2500_reset_mqtt(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.set_datetime",
     SetDatetimeAction,
     cv.Schema(
@@ -317,7 +330,7 @@ async def b2500_set_datetime(config, action_id, template_arg, args):
     return action_var
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.reboot",
     RebootAction,
     B2500_BASE_ACTION_SCHEMA,
@@ -329,7 +342,7 @@ async def b2500_reboot(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.factory_reset",
     FactoryResetAction,
     B2500_BASE_ACTION_SCHEMA,
@@ -341,7 +354,7 @@ async def b2500_factory_reset(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.set_dod",
     SetDodAction,
     cv.Schema(
@@ -361,7 +374,7 @@ async def b2500_set_dod(config, action_id, template_arg, args):
     return action_var
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.set_charge_mode",
     SetChargeModeAction,
     cv.Schema(
@@ -392,7 +405,7 @@ async def b2500_set_charge_mode(config, action_id, template_arg, args):
     return action_var
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.set_out_active",
     SetOutActiveAction,
     cv.Schema(
@@ -416,7 +429,7 @@ async def b2500_set_out_active(config, action_id, template_arg, args):
     return action_var
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.set_discharge_threshold",
     SetDischargeThresholdAction,
     cv.Schema(
@@ -437,7 +450,7 @@ async def b2500_set_discharge_threshold(config, action_id, template_arg, args):
     return action_var
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.set_timer",
     SetTimerAction,
     cv.Schema(
@@ -515,7 +528,7 @@ async def b2500_set_timer(config, action_id, template_arg, args):
     return action_var
 
 
-@automation.register_action(
+@register_action_compat(
     "b2500.set_adaptive_mode_enabled",
     SetAdaptiveModeEnabledAction,
     cv.Schema(

--- a/components/b2500/__init__.py
+++ b/components/b2500/__init__.py
@@ -45,15 +45,16 @@ AUTO_LOAD = ["b2500", "select"]
 
 
 def _get_max_connections():
-    if hasattr(esp32_ble_tracker, "max_connections"):
-        return esp32_ble_tracker.max_connections()
-
     if esp32_ble is not None:
         from esphome.core import CORE
 
         default = getattr(esp32_ble, "DEFAULT_MAX_CONNECTIONS", 1)
         idf = getattr(esp32_ble, "IDF_MAX_CONNECTIONS", default)
         return idf if CORE.is_esp32 else default
+
+    if hasattr(esp32_ble_tracker, "max_connections"):
+        # Backward-compatibility for older ESPHome releases
+        return esp32_ble_tracker.max_connections()
 
     # Fallback to a single instance if both helper APIs are unavailable
     return 1
@@ -213,6 +214,7 @@ B2500_BASE_ACTION_SCHEMA = maybe_simple_id(
             cv.Required(CONF_PASSWORD): cv.templatable(cv.string),
         }
     ),
+    synchronous=True,
 )
 async def b2500_set_wifi(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -241,6 +243,7 @@ async def b2500_set_wifi(config, action_id, template_arg, args):
             cv.Required(CONF_PASSWORD): cv.templatable(cv.string),
         }
     ),
+    synchronous=True,
 )
 async def b2500_set_mqtt(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -271,6 +274,7 @@ async def b2500_set_mqtt(config, action_id, template_arg, args):
             cv.Required(CONF_ID): cv.use_id(B2500ComponentBase),
         }
     ),
+    synchronous=True,
 )
 async def b2500_reset_mqtt(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -289,6 +293,7 @@ async def b2500_reset_mqtt(config, action_id, template_arg, args):
             ),
         },
     ),
+    synchronous=True,
 )
 async def b2500_set_datetime(config, action_id, template_arg, args):
     action_var = cg.new_Pvariable(action_id, template_arg)
@@ -316,6 +321,7 @@ async def b2500_set_datetime(config, action_id, template_arg, args):
     "b2500.reboot",
     RebootAction,
     B2500_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def b2500_reboot(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -327,6 +333,7 @@ async def b2500_reboot(config, action_id, template_arg, args):
     "b2500.factory_reset",
     FactoryResetAction,
     B2500_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def b2500_factory_reset(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -343,6 +350,7 @@ async def b2500_factory_reset(config, action_id, template_arg, args):
             cv.Required("dod"): cv.templatable(cv.int_),
         },
     ),
+    synchronous=True,
 )
 async def b2500_set_dod(config, action_id, template_arg, args):
     action_var = cg.new_Pvariable(action_id, template_arg)
@@ -369,6 +377,7 @@ async def b2500_set_dod(config, action_id, template_arg, args):
             )),
         },
     ),
+    synchronous=True,
 )
 async def b2500_set_charge_mode(config, action_id, template_arg, args):
     action_var = cg.new_Pvariable(action_id, template_arg)
@@ -394,6 +403,7 @@ async def b2500_set_charge_mode(config, action_id, template_arg, args):
             cv.Required("active"): cv.templatable(cv.boolean),
         },
     ),
+    synchronous=True,
 )
 async def b2500_set_out_active(config, action_id, template_arg, args):
     action_var = cg.new_Pvariable(action_id, template_arg)
@@ -416,6 +426,7 @@ async def b2500_set_out_active(config, action_id, template_arg, args):
             cv.Required("threshold"): cv.templatable(cv.int_),
         },
     ),
+    synchronous=True,
 )
 async def b2500_set_discharge_threshold(config, action_id, template_arg, args):
     action_var = cg.new_Pvariable(action_id, template_arg)
@@ -450,7 +461,8 @@ async def b2500_set_discharge_threshold(config, action_id, template_arg, args):
             "end_hour",
             "end_minute",
         )
-    )
+    ),
+    synchronous=True,
 )
 async def b2500_set_timer(config, action_id, template_arg, args):
     action_var = cg.new_Pvariable(action_id, template_arg)
@@ -513,6 +525,7 @@ async def b2500_set_timer(config, action_id, template_arg, args):
             cv.Required("enabled"): cv.templatable(cv.boolean),
         },
     ),
+    synchronous=True,
 )
 async def b2500_set_adaptive_mode_enabled(
     config,

--- a/components/b2500/automation.h
+++ b/components/b2500/automation.h
@@ -98,7 +98,8 @@ template<typename... Ts> class SetTimerAction : public Action<Ts...>, public Par
 
  public:
   void play(const Ts &... x) override {
-    auto timer = this->parent_->get_state()->get_timer(this->timer_.value(x...));
+    const auto timer_idx = this->timer_.value(x...);
+    auto timer = this->parent_->get_state()->get_timer(timer_idx);
 
     // Avoid binding references directly to packed struct fields
     auto timer_enabled = static_cast<bool>(timer.enabled);
@@ -114,7 +115,7 @@ template<typename... Ts> class SetTimerAction : public Action<Ts...>, public Par
     auto start_minute = this->start_minute_.value_or(x..., timer_start_minute).value_or(timer_start_minute);
     auto end_hour = this->end_hour_.value_or(x..., timer_end_hour).value_or(timer_end_hour);
     auto end_minute = this->end_minute_.value_or(x..., timer_end_minute).value_or(timer_end_minute);
-    this->parent_->set_timer(this->timer_.value(x...), enabled, output_power, start_hour, start_minute, end_hour, end_minute);
+    this->parent_->set_timer(timer_idx, enabled, output_power, start_hour, start_minute, end_hour, end_minute);
   }
 };
 

--- a/components/b2500/automation.h
+++ b/components/b2500/automation.h
@@ -99,6 +99,13 @@ template<typename... Ts> class SetTimerAction : public Action<Ts...>, public Par
  public:
   void play(const Ts &... x) override {
     const auto timer_idx = this->timer_.value(x...);
+    const auto max_timers = this->parent_->get_state()->get_number_of_timers();
+    if (timer_idx < 0 || timer_idx >= max_timers) {
+      ESP_LOGW("b2500.automation", "SetTimerAction: invalid timer index %d (valid range: 0-%d)", timer_idx,
+               max_timers - 1);
+      return;
+    }
+
     auto timer = this->parent_->get_state()->get_timer(timer_idx);
 
     // Avoid binding references directly to packed struct fields

--- a/components/b2500/automation.h
+++ b/components/b2500/automation.h
@@ -99,12 +99,21 @@ template<typename... Ts> class SetTimerAction : public Action<Ts...>, public Par
  public:
   void play(const Ts &... x) override {
     auto timer = this->parent_->get_state()->get_timer(this->timer_.value(x...));
-    auto enabled = this->enabled_.value_or(x..., timer.enabled).value_or(timer.enabled);
-    auto output_power = this->output_power_.value_or(x..., timer.output_power).value_or(timer.output_power);
-    auto start_hour = this->start_hour_.value_or(x..., timer.start.hour).value_or(timer.start.hour);
-    auto start_minute = this->start_minute_.value_or(x..., timer.start.minute).value_or(timer.start.minute);
-    auto end_hour = this->end_hour_.value_or(x..., timer.end.hour).value_or(timer.end.hour);
-    auto end_minute = this->end_minute_.value_or(x..., timer.end.minute).value_or(timer.end.minute);
+
+    // Avoid binding references directly to packed struct fields
+    auto timer_enabled = static_cast<bool>(timer.enabled);
+    auto timer_output_power = static_cast<int>(timer.output_power);
+    auto timer_start_hour = static_cast<int>(timer.start.hour);
+    auto timer_start_minute = static_cast<int>(timer.start.minute);
+    auto timer_end_hour = static_cast<int>(timer.end.hour);
+    auto timer_end_minute = static_cast<int>(timer.end.minute);
+
+    auto enabled = this->enabled_.value_or(x..., timer_enabled).value_or(timer_enabled);
+    auto output_power = this->output_power_.value_or(x..., timer_output_power).value_or(timer_output_power);
+    auto start_hour = this->start_hour_.value_or(x..., timer_start_hour).value_or(timer_start_hour);
+    auto start_minute = this->start_minute_.value_or(x..., timer_start_minute).value_or(timer_start_minute);
+    auto end_hour = this->end_hour_.value_or(x..., timer_end_hour).value_or(timer_end_hour);
+    auto end_minute = this->end_minute_.value_or(x..., timer_end_minute).value_or(timer_end_minute);
     this->parent_->set_timer(this->timer_.value(x...), enabled, output_power, start_hour, start_minute, end_hour, end_minute);
   }
 };

--- a/components/b2500/binary_sensor/b2500_binary_sensor_base.h
+++ b/components/b2500/binary_sensor/b2500_binary_sensor_base.h
@@ -2,6 +2,7 @@
 
 #include "../b2500_state.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/core/component.h"
 
 namespace esphome {
 namespace b2500 {


### PR DESCRIPTION
## Summary
- fix C++ compile error on ESPHome 2026.3.0 by explicitly including `esphome/core/component.h` in the binary sensor base header
- add `synchronous=True` to all `@automation.register_action(...)` registrations to match current ESPHome expectations and remove warnings
- keep BLE max-connection handling backward compatible while preferring the newer `esp32_ble` API first (fallback to `esp32_ble_tracker.max_connections()` for older ESPHome releases)
- update the firmware build workflow default ESPHome version to `2026.3.0` going forward

## Reproduction
Issue report from #240 reproduced against ESPHome 2026.3.0 with the `expected class-name before '{' token` failure in `B2500BinarySensorBase`.

## Validation
- `python3 -m py_compile components/b2500/__init__.py`
- `pytest -q` (3 passed)

Closes #240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default ESPHome firmware build version updated to 2026.3.0.
* **Bug Fixes / Reliability**
  * Improved Bluetooth connection selection for more reliable device connections across platforms.
  * Automation actions now run synchronously for more predictable behavior.
  * Timer handling refined with bounds checking and safer field handling for more consistent scheduling and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->