### PR TITLE
Clarify device version selection UI to reduce user confusion

### DIFF
--- a/src/components/StorageForm.tsx
+++ b/src/components/StorageForm.tsx
@@ -1,6 +1,18 @@
 // src/components/StorageForm.tsx
 import React from 'react';
-import { Button, TextField, Box, Typography, Grid, Alert } from '@mui/material';
+import {
+  Button,
+  TextField,
+  Box,
+  Typography,
+  Grid,
+  Alert,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  FormHelperText,
+} from '@mui/material';
 import { Storage, TemplateVersion } from '../types';
 import { templates } from '../templates';
 
@@ -31,7 +43,7 @@ const StorageForm: React.FC<StorageFormProps> = ({
 
   const handleAddStorage = () => {
     if (storages.length < maxStorages) {
-      onChange([...storages, { name: '', version: 1, mac_address: '' }]);
+      onChange([...storages, { name: '', version: 2, mac_address: '' }]);
     }
   };
 
@@ -108,24 +120,35 @@ const StorageForm: React.FC<StorageFormProps> = ({
               </Grid>
               {template.capabilities.requiresStorageVersion && (
                 <Grid item xs={4}>
-                  <TextField
-                    label="Version"
-                    type="number"
-                    value={storage.version}
-                    onChange={(e) =>
-                      handleStorageChange(
-                        index,
-                        'version',
-                        parseInt(e.target.value, 10)
-                      )
-                    }
+                  <FormControl
                     fullWidth
                     margin="normal"
-                    inputProps={{ min: 1, max: 2 }}
                     required
                     error={versionValid}
-                    helperText={'Version must be 1 or 2'}
-                  />
+                  >
+                    <InputLabel id={`storage-version-label-${index}`}>
+                      Device Version
+                    </InputLabel>
+                    <Select
+                      labelId={`storage-version-label-${index}`}
+                      label="Device Version"
+                      value={storage.version}
+                      onChange={(e) =>
+                        handleStorageChange(
+                          index,
+                          'version',
+                          e.target.value as number
+                        )
+                      }
+                    >
+                      <MenuItem value={2}>V2 (Standard)</MenuItem>
+                      <MenuItem value={1}>V1 (Legacy)</MenuItem>
+                    </Select>
+                    <FormHelperText>
+                      Most devices sold in recent years are V2. Only select V1
+                      if you are sure your device is a first-generation model.
+                    </FormHelperText>
+                  </FormControl>
                 </Grid>
               )}
               <Grid item xs={4}>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -88,7 +88,7 @@ export const defaultFormValues: FormValues = {
   },
   enable_dio_flash_mode: false,
   use_legacy_entity_names: true,
-  storages: [{ name: 'B2500', version: 1, mac_address: '00:00:00:00:00:00' }],
+  storages: [{ name: 'B2500', version: 2, mac_address: '00:00:00:00:00:00' }],
 };
 
 export const mergeDeep = (target: any, source: any) => {


### PR DESCRIPTION
Default to V2 (standard) instead of V1, and replace the bare number
input with a labeled dropdown that makes clear V2 is the standard
choice for most users.

https://claude.ai/code/session_01DDnPEwjzmmJv1daxMo4uVj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Replaced storage version numeric input field with a dropdown menu offering labeled options: V2 (Standard) and V1 (Legacy), providing clearer selection guidance.
  * Updated default storage version to V2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->