### PR TITLE
refactor: Convert add_on_message_callback to template for ESPHome 202…

### DIFF
--- a/components/b2500/b2500_state.cpp
+++ b/components/b2500/b2500_state.cpp
@@ -6,10 +6,6 @@
 namespace esphome {
 namespace b2500 {
 
-void B2500State::add_on_message_callback(std::function<void(B2500Message)> &&callback) {
-  this->message_callback_.add(std::move(callback));
-}
-
 void B2500State::message_received(B2500Message message, time_t timestamp) {
   info_timestamps_[message] = timestamp;
   this->last_message_received_timestamp_ = timestamp;

--- a/components/b2500/b2500_state.h
+++ b/components/b2500/b2500_state.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <unordered_map>
-#include <functional>
 
 #include "b2500_codec.h"
 
@@ -23,7 +22,10 @@ class B2500State {
 
   // Receiving Packets
   bool receive_packet(uint8_t *data, uint16_t data_len, time_t timestamp);
-  void add_on_message_callback(std::function<void(B2500Message)> &&callback);
+  template<typename F>
+  void add_on_message_callback(F &&callback) {
+    this->message_callback_.add(std::forward<F>(callback));
+  }
   bool is_message_received(B2500Message message) const;
 
   time_t get_last_message_received_timestamp() const { return this->last_message_received_timestamp_; }


### PR DESCRIPTION
  Title: refactor: Convert add_on_message_callback to template for ESPHome 2026.4.0

  Body:

  ## Summary

  - Replaces `std::function<void(B2500Message)>` in `add_on_message_callback` with a
    `template<typename F>` method using perfect forwarding (`std::forward<F>`)
  - Moves the implementation inline into the header (required for templates)
  - Removes the now-unused `#include <functional>` from `b2500_state.h`

  ## Motivation

  ESPHome 2026.4.0 (PR #14853) replaces `std::function` inside `CallbackManager`
  with a lightweight 8-byte `Callback` struct. Registering callbacks via `std::function`
  still compiles, but forces the slower heap-allocation path and loses the memory benefit
  of the new struct.

  Switching to a templated registration method allows the compiler to:
  - Avoid dynamic allocation entirely for `[this]` lambda captures
  - Reduce per-callback memory from ~16 bytes to ~8 bytes
  - Inline the callback invocation (no virtual dispatch)

  ## Changes

  | File | Change |
  |------|--------|
  | `components/b2500/b2500_state.h` | Declaration replaced with `template<typename F>` inline method; `#include
  <functional>` removed |
  | `components/b2500/b2500_state.cpp` | Out-of-line `add_on_message_callback` implementation removed |

  ## Backward Compatibility

  No breaking changes. The template accepts any callable — lambdas, function pointers,
  `std::function`, functors — so all existing call sites continue to compile without
  modification on all ESPHome versions.

  ## Test plan

  - [ ] `grep "std::function" components/b2500/b2500_state.h` returns no output
  - [ ] `grep "template<typename F>" components/b2500/b2500_state.h` shows the new method
  - [ ] `esphome compile` on an existing config completes without errors

  ---
  Go to https://github.com/tomquist/esphome-b2500/compare/main...devhemanthac-commits:main to open the PR with this
  description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined message callback registration to support a broader range of callable types, enhancing integration flexibility and improving callback handling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->