### PR TITLE
b2500: Migrate add_on_message_callback to template for ESPHome 2026.4.0

### DIFF
--- a/components/b2500/__init__.py
+++ b/components/b2500/__init__.py
@@ -261,7 +261,7 @@ async def b2500_set_wifi(config, action_id, template_arg, args):
 async def b2500_set_mqtt(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    cg.add(var.set_ssl(config[CONF_SSL]))
+    cg.add(var.set_ssl(await cg.templatable(config[CONF_SSL], args, bool)))
     cg.add(var.set_host(await cg.templatable(
         config[CONF_HOST],
         args,
@@ -326,7 +326,8 @@ async def b2500_set_datetime(config, action_id, template_arg, args):
             ("month", datetime_config[CONF_MONTH]),
             ("year", datetime_config[CONF_YEAR]),
         )
-        cg.add(action_var.set_datetime(datetime_struct))
+        template_ = await cg.templatable(datetime_struct, [], cg.ESPTime)
+        cg.add(action_var.set_datetime(template_))
     return action_var
 
 

--- a/components/b2500/b2500_state.cpp
+++ b/components/b2500/b2500_state.cpp
@@ -6,10 +6,6 @@
 namespace esphome {
 namespace b2500 {
 
-void B2500State::add_on_message_callback(std::function<void(B2500Message)> &&callback) {
-  this->message_callback_.add(std::move(callback));
-}
-
 void B2500State::message_received(B2500Message message, time_t timestamp) {
   info_timestamps_[message] = timestamp;
   this->last_message_received_timestamp_ = timestamp;

--- a/components/b2500/b2500_state.h
+++ b/components/b2500/b2500_state.h
@@ -23,7 +23,9 @@ class B2500State {
 
   // Receiving Packets
   bool receive_packet(uint8_t *data, uint16_t data_len, time_t timestamp);
-  void add_on_message_callback(std::function<void(B2500Message)> &&callback);
+  template<typename F> void add_on_message_callback(F &&callback) {
+    this->message_callback_.add(std::forward<F>(callback));
+  }
   bool is_message_received(B2500Message message) const;
 
   time_t get_last_message_received_timestamp() const { return this->last_message_received_timestamp_; }

--- a/tests/component_tests/b2500/test_b2500.py
+++ b/tests/component_tests/b2500/test_b2500.py
@@ -60,3 +60,24 @@ def test_b2500_set_timer_generation_uses_integer_templates(generate_main):
         if "return 2;" in main_cpp[idx: idx + 200]:
             break
         search_start = idx + len(lambda_set_timer)
+
+    # ESPHome 2026.4 introduced TemplatableFn (4 bytes, function-pointer-only),
+    # which static_asserts when fed a raw value instead of a callable. All
+    # TEMPLATABLE_VALUE setters must therefore be passed via cg.templatable so
+    # constants are wrapped in stateless lambdas. On 2025.x raw values are
+    # still accepted, but the codegen path must go through cg.templatable.
+    from esphome.const import __version__ as esphome_version
+
+    major, minor = (int(p) for p in esphome_version.split(".", 2)[:2])
+    requires_lambda_wrap = (major, minor) >= (2026, 4)
+
+    # set_mqtt's `ssl` defaults to False (not exposed in YAML).
+    assert "set_ssl(" in main_cpp
+    # set_datetime with a struct literal.
+    assert "set_datetime(" in main_cpp
+    if requires_lambda_wrap:
+        # TemplatableFn rejects raw constants — both must be wrapped via
+        # cg.templatable into stateless lambdas.
+        assert "set_ssl(false)" not in main_cpp
+        assert "set_ssl(true)" not in main_cpp
+        assert "set_datetime(ESPTime" not in main_cpp

--- a/tests/component_tests/b2500/test_b2500.py
+++ b/tests/component_tests/b2500/test_b2500.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 import tempfile
 import pytest
 
@@ -6,13 +7,13 @@ from tests.component_tests.conftest import generate_main
 
 
 @pytest.mark.parametrize(
-    "yaml_file, expected",
+    "yaml_file, class_name",
     [
-        ("test_b2500.yaml", "new b2500::B2500ComponentV1()"),
-        ("test_b2500_v2.yaml", "new b2500::B2500ComponentV2()"),
+        ("test_b2500.yaml", "B2500ComponentV1"),
+        ("test_b2500_v2.yaml", "B2500ComponentV2"),
     ],
 )
-def test_b2500_component_generation(generate_main, yaml_file: str, expected: str):
+def test_b2500_component_generation(generate_main, yaml_file: str, class_name: str):
     yaml_path = Path(__file__).with_name(yaml_file)
     contents = yaml_path.read_text()
     component_dir = (Path(__file__).parents[3] / "components").resolve()
@@ -23,7 +24,10 @@ def test_b2500_component_generation(generate_main, yaml_file: str, expected: str
         temp_path = f.name
 
     main_cpp = generate_main(temp_path)
-    assert expected in main_cpp
+    # ESPHome 2025.x renders as `new b2500::ClassName()`, while 2026.4+
+    # uses placement new: `new(<id>) b2500::ClassName()`.
+    pattern = rf"new(?:\([^)]*\))?\s+b2500::{class_name}\(\)"
+    assert re.search(pattern, main_cpp), main_cpp
 
 
 def test_b2500_set_timer_generation_uses_integer_templates(generate_main):
@@ -38,8 +42,21 @@ def test_b2500_set_timer_generation_uses_integer_templates(generate_main):
 
     main_cpp = generate_main(temp_path)
 
-    assert "set_timer(1)" in main_cpp
+    # Older ESPHome versions emit `set_timer(1)` for literal int values, while
+    # 2026.4+ wraps every templatable in a lambda (`set_timer([]() -> int { return 1; })`).
+    # Both forms prove the int-typed `templatable` overload is used (not bool/float).
+    int_lambda_re = re.compile(r"set_timer\(\[\]\(\) -> int \{[^}]*return\s+1;\s*\}\)")
+    assert "set_timer(1)" in main_cpp or int_lambda_re.search(main_cpp), main_cpp
+
     lambda_set_timer = "set_timer([]() -> int {"
     assert lambda_set_timer in main_cpp
-    lambda_set_timer_index = main_cpp.index(lambda_set_timer)
-    assert "return 2;" in main_cpp[lambda_set_timer_index: lambda_set_timer_index + 200]
+    # The literal-int lambda (return 1) may appear before the user lambda
+    # (return 2). Find the occurrence that corresponds to `timer: !lambda return 2;`.
+    search_start = 0
+    while True:
+        idx = main_cpp.find(lambda_set_timer, search_start)
+        if idx == -1:
+            pytest.fail("Did not find set_timer lambda returning 2")
+        if "return 2;" in main_cpp[idx: idx + 200]:
+            break
+        search_start = idx + len(lambda_set_timer)

--- a/tests/component_tests/b2500/test_b2500_v2_actions.yaml
+++ b/tests/component_tests/b2500/test_b2500_v2_actions.yaml
@@ -32,6 +32,21 @@ esphome:
           generation: 2
           timer: !lambda 'return 2;'
           start_hour: !lambda 'return 6;'
+      - b2500.set_mqtt:
+          id: b2500_device
+          host: "broker.local"
+          port: 1883
+          username: "user"
+          password: "pass"
+      - b2500.set_datetime:
+          id: b2500_device
+          datetime:
+            year: 2025
+            month: 1
+            day: 1
+            hour: 0
+            minute: 0
+            second: 0
 
 time:
   - platform: sntp


### PR DESCRIPTION
ESPHome 2026.4.0 replaces std::function with a lightweight Callback struct in CallbackManager (esphome/esphome#14853). Convert the registration method to a template so [this] lambdas avoid the heap-allocation path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MQTT SSL configuration now supports dynamic templating for flexible connectivity options
  * Datetime values now support dynamic templating for improved scheduling control

* **Tests**
  * Expanded test coverage to support multiple ESPHome versions
  * Added comprehensive tests for new MQTT and datetime configuration actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->