### PR TITLE
Fix set_datetime to use utcnow() instead of now()

### DIFF
--- a/src/template_v2.jinja2
+++ b/src/template_v2.jinja2
@@ -607,7 +607,7 @@ text_sensor:
       icon: mdi:identifier
 {% if storage.version >= 2 %}
     device_time:
-      name: "{{ sensor_prefix(loop.index, storage) }} Device Time"
+      name: "{{ sensor_prefix(loop.index, storage) }} Device Time UTC"
       id: b2500_device_time_{{ loop.index }}
       device_id: b2500_device_{{ loop.index }}
 {%- if mqtt.enabled %}

--- a/src/template_v2.jinja2
+++ b/src/template_v2.jinja2
@@ -273,7 +273,7 @@ ble_client:
         - delay: 1s
         - b2500.set_datetime:
             id: b2500_{{ loop.index }}
-            datetime: !lambda 'return id(sntp_time).now();'
+            datetime: !lambda 'return id(sntp_time).utcnow();'
 
     on_disconnect:
       then:

--- a/src/template_v2_minimal.jinja2
+++ b/src/template_v2_minimal.jinja2
@@ -487,7 +487,7 @@ ble_client:
         - delay: 1s
         - b2500.set_datetime:
             id: b2500_{{ loop.index }}
-            datetime: !lambda 'return id(sntp_time).now();'
+            datetime: !lambda 'return id(sntp_time).utcnow();'
 
     on_disconnect:
       then:


### PR DESCRIPTION
As described in #255 I noticed that the Device Time is set differently between esphome-b2500 and the app, which uses UTC time. This pull request matches the behavior to the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device datetime synchronization now uses UTC when BLE devices connect, ensuring consistent timestamps across timezones.
  * For storage version 2 and above, the device time sensor label is updated to "Device Time UTC" to reflect UTC-based timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->