### PR TITLE
Add warning about timer flash wear in config form and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Replace `{timer}` with the timer slot number (`1` to `5`). Each slot is exposed 
 
 Older devices (firmware < 218) only expose 3 timer slots; slots `4` and `5` require newer firmware.
 
+> **⚠️ Do not use the timers to build a zero feed-in / zero-export automation.** It is tempting to repeatedly rewrite the timer output power based on your current consumption (e.g. every few seconds or minutes) to keep grid feed-in at zero. **Don't.** Every timer write is persisted to the device's flash/EEPROM over BLE, which only tolerates a limited number of write cycles. Continuously steering the output through the timers will wear the flash out and can permanently damage the device. Use the timers only for occasional schedule changes. For a dynamic control loop, drive the output limit instead (e.g. via [hm2mqtt](https://github.com/tomquist/hm2mqtt), which does not write to flash by default). See [Set Timer Configuration](#set-timer-configuration-b2500storagetimerset---v2-only) for more details.
+
 ### System Control
 
 | Description | Read Topic | Write Topic | Available in version |

--- a/src/components/AdvancedSection.tsx
+++ b/src/components/AdvancedSection.tsx
@@ -13,6 +13,8 @@ import {
   FormHelperText,
   FormControl,
   SelectChangeEvent,
+  Alert,
+  Link,
 } from '@mui/material';
 import { ExpandMore } from '@mui/icons-material';
 import BooleanField from './BooleanField';
@@ -235,12 +237,36 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({
           />
         )}
         {currentTemplate.capabilities.canEnableTimerQuery && (
-          <BooleanField
-            value={formValues}
-            onChange={handleInputChange}
-            prop="enable_timer_query"
-            label="Enable Timer Query (v2 & 3 only)"
-          />
+          <>
+            <BooleanField
+              value={formValues}
+              onChange={handleInputChange}
+              prop="enable_timer_query"
+              label="Enable Timer Query (v2 & 3 only)"
+            />
+            <Alert severity="warning" sx={{ mt: 1, mb: 2 }}>
+              <strong>
+                Don't use the timers to build a zero feed-in / zero-export
+                automation.
+              </strong>{' '}
+              Repeatedly rewriting the timer output power based on your current
+              consumption seems like an easy way to keep grid feed-in at zero,
+              but every timer change is written to the device's flash/EEPROM,
+              which only tolerates a limited number of write cycles.
+              Continuously steering the output through the timers will wear the
+              flash out and can permanently damage the device. Use the timers
+              only for occasional schedule changes. For a dynamic control loop,
+              drive the output limit instead (e.g. via{' '}
+              <Link
+                href="https://github.com/tomquist/hm2mqtt"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                hm2mqtt
+              </Link>
+              , which does not write to flash by default).
+            </Alert>
+          </>
         )}
         {currentTemplate.capabilities.canEnableExperimentalCommands && (
           <BooleanField

--- a/src/components/AdvancedSection.tsx
+++ b/src/components/AdvancedSection.tsx
@@ -13,8 +13,6 @@ import {
   FormHelperText,
   FormControl,
   SelectChangeEvent,
-  Alert,
-  Link,
 } from '@mui/material';
 import { ExpandMore } from '@mui/icons-material';
 import BooleanField from './BooleanField';
@@ -237,36 +235,12 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({
           />
         )}
         {currentTemplate.capabilities.canEnableTimerQuery && (
-          <>
-            <BooleanField
-              value={formValues}
-              onChange={handleInputChange}
-              prop="enable_timer_query"
-              label="Enable Timer Query (v2 & 3 only)"
-            />
-            <Alert severity="warning" sx={{ mt: 1, mb: 2 }}>
-              <strong>
-                Don't use the timers to build a zero feed-in / zero-export
-                automation.
-              </strong>{' '}
-              Repeatedly rewriting the timer output power based on your current
-              consumption seems like an easy way to keep grid feed-in at zero,
-              but every timer change is written to the device's flash/EEPROM,
-              which only tolerates a limited number of write cycles.
-              Continuously steering the output through the timers will wear the
-              flash out and can permanently damage the device. Use the timers
-              only for occasional schedule changes. For a dynamic control loop,
-              drive the output limit instead (e.g. via{' '}
-              <Link
-                href="https://github.com/tomquist/hm2mqtt"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                hm2mqtt
-              </Link>
-              , which does not write to flash by default).
-            </Alert>
-          </>
+          <BooleanField
+            value={formValues}
+            onChange={handleInputChange}
+            prop="enable_timer_query"
+            label="Enable Timer Query (v2 & 3 only)"
+          />
         )}
         {currentTemplate.capabilities.canEnableExperimentalCommands && (
           <BooleanField

--- a/src/components/ConfigForm.tsx
+++ b/src/components/ConfigForm.tsx
@@ -12,6 +12,7 @@ import {
   MenuItem,
   SelectChangeEvent,
   FormHelperText,
+  Alert,
 } from '@mui/material';
 import {
   EspTemperatureSettings,
@@ -139,6 +140,26 @@ const ConfigForm: React.FC<ConfigFormProps> = ({
     formValues.friendly_name.trim() === '';
   return (
     <Paper elevation={3} sx={{ padding: 2 }}>
+      <Alert severity="warning" sx={{ mb: 2 }}>
+        <strong>
+          Don't use the timers to build a zero feed-in / zero-export automation.
+        </strong>{' '}
+        Repeatedly rewriting the timer output power based on your current
+        consumption seems like an easy way to keep grid feed-in at zero, but
+        every timer change is written to the device's flash/EEPROM, which only
+        tolerates a limited number of write cycles. Continuously steering the
+        output through the timers will wear the flash out and can permanently
+        damage the device. Use the timers only for occasional schedule changes.
+        For a dynamic control loop, drive the output limit instead (e.g. via{' '}
+        <Link
+          href="https://github.com/tomquist/hm2mqtt"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          hm2mqtt
+        </Link>
+        , which does not write to flash by default).
+      </Alert>
       <Typography variant="h6">General Settings</Typography>
       <FormControl fullWidth margin="normal">
         <InputLabel id="variant-label">Configuration Version</InputLabel>


### PR DESCRIPTION
## Summary
Added prominent warnings to discourage users from using timers for continuous zero feed-in automation, which can damage devices through flash memory wear.

## Key Changes
- **ConfigForm.tsx**: Added a Material-UI `Alert` component with a warning message at the top of the configuration form that explains the risks of repeatedly writing to device timers
  - Includes a link to [hm2mqtt](https://github.com/tomquist/hm2mqtt) as the recommended alternative for dynamic control
  - Warning is styled with `severity="warning"` and positioned prominently before form fields
  
- **README.md**: Added a warning block in the Timer Configuration section documenting the same guidance
  - Explains that each timer write persists to flash/EEPROM over BLE with limited write cycles
  - Recommends using timers only for occasional schedule changes
  - Points users to output limit control as the proper approach for dynamic automation

## Implementation Details
- The warning in ConfigForm uses Material-UI's `Alert` component with proper spacing (`mb: 2`)
- Includes a properly configured external link with security attributes (`target="_blank"`, `rel="noopener noreferrer"`)
- Both UI and documentation convey the same critical safety message to prevent device damage from flash wear

https://claude.ai/code/session_015VfzApU4cKWYKLsUwxhyX8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance warning against using timers for rapidly changing control loops.
  - Recommended dynamic output-limit control for zero feed-in or zero-export automation.

- **User Interface**
  - Added a prominent warning to the configuration form explaining potential device memory wear from frequent timer updates.
  - Linked users to an alternative approach that avoids repeated flash writes by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->