### PR TITLE
Add Marstek ecosystem family documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 
 # ESPHome B2500 Config Generator
 
+<!-- marstek-family:start -->
+**🔋 The Marstek ecosystem.** This repo is part of a family of open-source tools for Marstek batteries (B2500, Venus, Jupiter, …):
+
+| Project | What it does |
+|---|---|
+| [hm2mqtt](https://github.com/tomquist/hm2mqtt) | Brings your battery into your smart home, turning its raw data into readable sensors and controls (e.g. in Home Assistant) |
+| [hame-relay](https://github.com/tomquist/hame-relay) | Connects the official Marstek cloud/app and your local smart home so both work together, forwarding data whichever way your battery is set up |
+| [marsrelay](https://github.com/tomquist/marsrelay) | Runs your battery completely offline, with no internet or Marstek cloud, while still sending all its data to your smart home |
+| [AstraMeter](https://github.com/tomquist/astrameter) | Tells your battery your live grid usage (read from your existing meter) so it charges and discharges to avoid buying or selling power |
+| [hmjs](https://github.com/tomquist/hmjs) | Sets up and configures B2500 batteries over Bluetooth, right from your web browser, with no app or account needed |
+| **esphome-b2500** (this repo) | Continuously monitors and controls a B2500 over Bluetooth using a small ESP32 board |
+<!-- marstek-family:end -->
+
 ## Overview
 
 This tool helps you create configuration files for your B2500 device and generate the necessary firmware without requiring any technical knowledge or software installation on your computer. You can do everything through your web browser.


### PR DESCRIPTION
## Summary
Added a new section to the README that documents this project as part of the broader Marstek ecosystem, providing context about related open-source tools and their purposes.

## Changes
- Added a "Marstek ecosystem" section with a table listing related projects:
  - hm2mqtt: Smart home integration for Marstek batteries
  - hame-relay: Cloud and local smart home synchronization
  - marsrelay: Offline battery operation
  - AstraMeter: Grid usage awareness for charging/discharging optimization
  - hmjs: Web-based battery setup and configuration
  - esphome-b2500: This repository's role in the ecosystem
- Wrapped the section with HTML comments (`marstek-family:start` and `marstek-family:end`) to allow for automated updates across the ecosystem

## Details
This change improves discoverability and helps users understand how this project fits within the larger Marstek tooling ecosystem, making it easier for them to find complementary tools for their battery management needs.

https://claude.ai/code/session_014X7oipnV3LXbrsLYoii4yq