### PR TITLE
Handle empty Wi-Fi info packets gracefully in B2500 codec

### DIFF
--- a/components/b2500/b2500_codec.cpp
+++ b/components/b2500/b2500_codec.cpp
@@ -159,18 +159,30 @@ bool B2500Codec::parse_wifi_info(uint8_t *data, uint16_t data_len, WifiInfoPacke
     ESP_LOGW(TAG, "Not a CMD_WIFI_INFO packet");
     return false;
   }
-  if (data_len < sizeof(B2500PacketHeader) + 2) {
-    ESP_LOGW(TAG, "Packet too short for CMD_WIFI_INFO, expected at least %d, got %d", sizeof(B2500PacketHeader) + 2,
-             data_len);
-    ESP_LOGW(TAG, "data: %s", format_hex_pretty(data, data_len).c_str());
-    return false;
+  const size_t header_size = sizeof(B2500PacketHeader);
+  const size_t payload_size = data_len > header_size ? (data_len - header_size) : 0;
+
+  // Devices which are not connected to a Wi-Fi network answer with a header-only
+  // packet (73 04 23 09). Report "no Wi-Fi" instead of failing to parse.
+  if (payload_size == 0) {
+    ESP_LOGD(TAG, "Empty CMD_WIFI_INFO payload, device is not connected to a Wi-Fi network");
+    payload.signal = 0;
+    payload.ssid = "";
+    return true;
   }
 
   // Extract the signal strength
-  payload.signal = data[sizeof(B2500PacketHeader)];
+  payload.signal = data[header_size];
+
+  // The SSID follows the signal strength and a separator byte
+  if (payload_size < 2) {
+    ESP_LOGD(TAG, "CMD_WIFI_INFO payload contains no SSID");
+    payload.ssid = "";
+    return true;
+  }
 
   // Calculate the start and end pointers for the SSID string
-  const char *start = reinterpret_cast<const char *>(data + sizeof(B2500PacketHeader) + 2);
+  const char *start = reinterpret_cast<const char *>(data + header_size + 2);
   const char *end = reinterpret_cast<const char *>(data + data_len);
 
   // Newer firmware versions may send invalid/empty SSID data, handle gracefully

--- a/tests/codec_tests/parse_wifi_info_test.cpp
+++ b/tests/codec_tests/parse_wifi_info_test.cpp
@@ -1,0 +1,68 @@
+// Regression tests for B2500Codec::parse_wifi_info.
+//
+// Compiled and run on the host by test_codec.py, using the ESPHome stubs in
+// stubs/.
+
+#include "b2500_codec.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using esphome::b2500::B2500Codec;
+using esphome::b2500::WifiInfoPacket;
+
+static int failures = 0;
+
+static void expect_parsed(const char *name, std::vector<uint8_t> packet, uint8_t signal, const std::string &ssid) {
+  B2500Codec codec;
+  WifiInfoPacket payload;
+  payload.signal = 0xEE;
+  payload.ssid = "previous";
+
+  printf("--- %s\n", name);
+  if (!codec.parse_wifi_info(packet.data(), packet.size(), payload)) {
+    printf("FAIL: %s: expected the packet to parse\n", name);
+    failures++;
+    return;
+  }
+  if (payload.signal != signal) {
+    printf("FAIL: %s: expected signal %d, got %d\n", name, signal, payload.signal);
+    failures++;
+  }
+  if (payload.ssid != ssid) {
+    printf("FAIL: %s: expected ssid '%s', got '%s'\n", name, ssid.c_str(), payload.ssid.c_str());
+    failures++;
+  }
+}
+
+static void expect_rejected(const char *name, std::vector<uint8_t> packet) {
+  B2500Codec codec;
+  WifiInfoPacket payload;
+
+  printf("--- %s\n", name);
+  if (codec.parse_wifi_info(packet.data(), packet.size(), payload)) {
+    printf("FAIL: %s: expected the packet to be rejected\n", name);
+    failures++;
+  }
+}
+
+int main() {
+  // A device which is not connected to a Wi-Fi network answers with a
+  // header-only packet (see issue #291).
+  expect_parsed("header only", {0x73, 0x04, 0x23, 0x09}, 0, "");
+  expect_parsed("signal only", {0x73, 0x05, 0x23, 0x09, 0x40}, 0x40, "");
+  expect_parsed("signal and separator, no ssid", {0x73, 0x06, 0x23, 0x09, 0x40, 0x00}, 0x40, "");
+  expect_parsed("signal and ssid", {0x73, 0x0A, 0x23, 0x09, 0x40, 0x00, 'h', 'o', 'm', 'e'}, 0x40, "home");
+  expect_parsed("non-printable ssid", {0x73, 0x08, 0x23, 0x09, 0x40, 0x00, 0x01, 0x02}, 0x40, "");
+
+  expect_rejected("truncated header", {0x73, 0x04, 0x23});
+  expect_rejected("wrong command", {0x73, 0x05, 0x23, 0x03, 0x40});
+
+  if (failures != 0) {
+    printf("%d assertion(s) failed\n", failures);
+    return 1;
+  }
+  printf("all assertions passed\n");
+  return 0;
+}

--- a/tests/codec_tests/stubs/README.md
+++ b/tests/codec_tests/stubs/README.md
@@ -1,0 +1,5 @@
+# ESPHome stub headers
+
+`b2500_codec.cpp` only needs `format_hex_pretty()` and the `ESP_LOG*` macros
+from ESPHome, so the codec can be compiled and exercised on the host with these
+minimal stand-ins instead of a full ESPHome/PlatformIO toolchain.

--- a/tests/codec_tests/stubs/esphome/core/helpers.h
+++ b/tests/codec_tests/stubs/esphome/core/helpers.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace esphome {
+
+inline std::string format_hex_pretty(const uint8_t *data, size_t length) {
+  std::string result;
+  char byte[3];
+  for (size_t i = 0; i < length; i++) {
+    if (i != 0) {
+      result += '.';
+    }
+    snprintf(byte, sizeof(byte), "%02X", data[i]);
+    result += byte;
+  }
+  return result;
+}
+
+}  // namespace esphome

--- a/tests/codec_tests/stubs/esphome/core/log.h
+++ b/tests/codec_tests/stubs/esphome/core/log.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdio>
+
+#define B2500_TEST_LOG(level, tag, fmt, ...) printf("[" level "][%s] " fmt "\n", tag, ##__VA_ARGS__)
+
+#define ESP_LOGE(tag, fmt, ...) B2500_TEST_LOG("E", tag, fmt, ##__VA_ARGS__)
+#define ESP_LOGW(tag, fmt, ...) B2500_TEST_LOG("W", tag, fmt, ##__VA_ARGS__)
+#define ESP_LOGI(tag, fmt, ...) B2500_TEST_LOG("I", tag, fmt, ##__VA_ARGS__)
+#define ESP_LOGD(tag, fmt, ...) B2500_TEST_LOG("D", tag, fmt, ##__VA_ARGS__)
+#define ESP_LOGV(tag, fmt, ...) B2500_TEST_LOG("V", tag, fmt, ##__VA_ARGS__)

--- a/tests/codec_tests/test_codec.py
+++ b/tests/codec_tests/test_codec.py
@@ -1,0 +1,39 @@
+"""Host-compiled tests for the B2500 codec.
+
+The codec only depends on ESPHome for logging and hex formatting, so it can be
+compiled with the stubs in ``stubs/`` and exercised without a firmware build.
+"""
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+HERE = Path(__file__).parent
+REPO_ROOT = HERE.parents[1]
+COMPONENT_DIR = REPO_ROOT / "components" / "b2500"
+
+
+@pytest.mark.skipif(shutil.which("g++") is None, reason="g++ is not available")
+@pytest.mark.parametrize("source", sorted(HERE.glob("*_test.cpp")), ids=lambda p: p.stem)
+def test_codec(source: Path, tmp_path: Path):
+    binary = tmp_path / source.stem
+    compile_result = subprocess.run(
+        [
+            "g++",
+            "-std=c++17",
+            "-Wall",
+            f"-I{COMPONENT_DIR}",
+            f"-I{HERE / 'stubs'}",
+            "-o",
+            str(binary),
+            str(source),
+            str(COMPONENT_DIR / "b2500_codec.cpp"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+
+    run_result = subprocess.run([str(binary)], capture_output=True, text=True)
+    assert run_result.returncode == 0, run_result.stdout + run_result.stderr


### PR DESCRIPTION
## Summary
Improved the B2500 codec's `parse_wifi_info()` method to gracefully handle Wi-Fi info packets from devices that are not connected to a network, rather than failing to parse them.

## Key Changes
- Refactored packet validation to calculate payload size separately from the header
- Added special handling for empty payloads (header-only packets): devices not connected to Wi-Fi now return successfully with signal strength of 0 and empty SSID instead of failing
- Added graceful handling for payloads that contain signal strength but no SSID data
- Improved logging: changed error logs to debug logs for expected conditions (empty payload, missing SSID)
- Replaced hardcoded `sizeof(B2500PacketHeader)` with a named constant for better readability

## Implementation Details
- Empty payloads are now recognized as a valid state indicating "no Wi-Fi connection" rather than a parsing error
- The parser now returns `true` with default values (signal=0, ssid="") for both empty payloads and payloads with only signal strength but no SSID
- This change maintains backward compatibility while supporting a broader range of device states

https://claude.ai/code/session_01K1CJXKm4uk3FF3NCRTsWmr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Wi‑Fi status responses when a device is disconnected.
  * Wi‑Fi information now displays correctly when signal, SSID, or payload details are unavailable.
  * Removed failures caused by incomplete or header-only Wi‑Fi responses.

* **Tests**
  * Added coverage for valid, malformed, truncated, and unexpected Wi‑Fi responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->