### PR TITLE
Update ESPHome version references to 2026.8.1

### DIFF
--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -63,7 +63,7 @@ jobs:
         uses: esphome/build-action@v7.1.0
         with:
           yaml-file: device.yaml
-          version: ${{ github.event.client_payload.esphome_version || '2026.3.0' }}
+          version: ${{ github.event.client_payload.esphome_version || '2026.8.1' }}
         continue-on-error: true
 
       - name: Debug on failure

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        esphome_version: ["latest", "2025.12.4"]
+        esphome_version: ["latest", "2026.8.1"]
         example:
           - basic-v1
           - basic-v2
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        esphome_version: ["latest", "2025.12.4"]
+        esphome_version: ["latest", "2026.8.1"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Updated ESPHome version references across CI/CD workflows to use version 2026.8.1 instead of the previous versions.

## Key Changes
- Updated the pinned ESPHome version in the PR workflow matrix from `2025.12.4` to `2026.8.1`
- Updated the default ESPHome version in the build workflow from `2026.3.0` to `2026.8.1`
- These changes affect both the test matrix strategy and the fallback version used in the ESPHome build action

## Details
The changes ensure that:
- Pull request checks run against the latest stable ESPHome version (2026.8.1) alongside the `latest` tag
- The build workflow uses 2026.8.1 as the default version when no explicit version is provided via webhook payload

https://claude.ai/code/session_01KKycijLXCGShV4WusXwr5E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default ESPHome build version to 2026.8.1.
  * Updated pull request validation to test ESPHome 2026.8.1 alongside the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->