### PR TITLE
Fix BLE scan parameters for ESP-IDF 5.5.5 compatibility

### DIFF
--- a/src/template_v2.jinja2
+++ b/src/template_v2.jinja2
@@ -274,6 +274,13 @@ esp32_ble:
   max_connections: {{ storages|length }}
 
 esp32_ble_tracker:
+  # ESP-IDF 5.5.5 (ESPHome 2026.7.1) made the controller honor the scan window
+  # strictly, so the 30ms/320ms default listens only 9.4% of the time and misses
+  # most of the storage's advertisements while WiFi shares the radio. The client
+  # then never sees the device again and loops on status=133.
+  scan_parameters:
+    interval: 320ms
+    window: 300ms
 
 ble_client:
 {%- for storage in storages %}

--- a/src/template_v2_minimal.jinja2
+++ b/src/template_v2_minimal.jinja2
@@ -498,6 +498,13 @@ esp32_ble:
   max_connections: {{ storages|length }}
 
 esp32_ble_tracker:
+  # ESP-IDF 5.5.5 (ESPHome 2026.7.1) made the controller honor the scan window
+  # strictly, so the 30ms/320ms default listens only 9.4% of the time and misses
+  # most of the storage's advertisements while WiFi shares the radio. The client
+  # then never sees the device again and loops on status=133.
+  scan_parameters:
+    interval: 320ms
+    window: 300ms
 
 ble_client:
 {%- for storage in storages %}


### PR DESCRIPTION
## Summary
Updated BLE tracker scan parameters in both template files to address compatibility issues with ESP-IDF 5.5.5 (ESPHome 2026.7.1), which now strictly enforces scan window timing.

## Key Changes
- Added explicit `scan_parameters` configuration to `esp32_ble_tracker` in both `template_v2.jinja2` and `template_v2_minimal.jinja2`
- Set scan interval to 320ms and window to 300ms (previously using implicit defaults of 30ms/320ms)
- Added explanatory comment documenting the issue: the default 30ms/320ms window only listens 9.4% of the time, causing missed BLE advertisements when WiFi shares the radio, resulting in status=133 errors

## Implementation Details
The change increases the scan window from 30ms to 300ms while maintaining the 320ms interval, significantly improving the duty cycle from 9.4% to 93.75%. This allows the BLE tracker to reliably detect storage device advertisements even when WiFi is actively using the shared radio on ESP32 devices.

https://claude.ai/code/session_012RdetFrrRrAU2ZisDLH6DY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth device discovery reliability, especially when Wi‑Fi and Bluetooth share the radio.
  * Reduced missed advertisements and connection failures caused by restrictive default scanning behavior.
  * Applied the fix to both standard and minimal ESP32 configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->