### PR TITLE
Report compile progress while the firmware builds

### DIFF
--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -59,7 +59,9 @@ jobs:
       # The web builder polls this document to follow the build and to offer
       # flashing the firmware right after it finished.
       - name: Publish build status
-        run: ./scripts/publish-build-status.sh building
+        env:
+          STEP: preparing
+        run: ./scripts/publish-build-status.sh building "Preparing the build" || true
 
       - name: Decrypt the ZIP password
         id: decrypt_password
@@ -81,6 +83,17 @@ jobs:
         run: |
           node scripts/render.js
 
+      # The compile is by far the longest part of a build, so a watcher reports
+      # how far along it is while the step below runs. It keeps going until the
+      # step after the build stops it.
+      - name: Report compile progress
+        env:
+          STEP: compiling
+        run: |
+          ./scripts/publish-build-status.sh building "Compiling the firmware" || true
+          nohup ./scripts/watch-build-progress.sh > progress-watcher.log 2>&1 &
+          echo "PROGRESS_WATCHER_PID=$!" >> "$GITHUB_ENV"
+
       - name: Build firmware
         id: esphome-build
         uses: esphome/build-action@v7.1.0
@@ -91,6 +104,20 @@ jobs:
           # to assemble an esp-web-tools manifest itself.
           complete-manifest: true
         continue-on-error: true
+
+      # Before any of the paths below publish a status of their own, so that a
+      # late progress update cannot overwrite the build result.
+      - name: Stop reporting compile progress
+        if: always()
+        run: |
+          if [[ -n "${PROGRESS_WATCHER_PID:-}" ]]; then
+            kill "$PROGRESS_WATCHER_PID" 2> /dev/null || true
+          fi
+          if [[ -s progress-watcher.log ]]; then
+            echo "::group::Compile progress reporting"
+            cat progress-watcher.log
+            echo "::endgroup::"
+          fi
 
       - name: Debug on failure
         if: steps.esphome-build.outcome == 'failure'
@@ -103,6 +130,11 @@ jobs:
       - name: Exit on build failure  
         if: steps.esphome-build.outcome == 'failure'
         run: exit 1
+
+      - name: Publish packaging status
+        env:
+          STEP: packaging
+        run: ./scripts/publish-build-status.sh building "Packaging the firmware" || true
 
       - name: Zip the firmware with a password
         run: |

--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -91,6 +91,7 @@ jobs:
           STEP: compiling
         run: |
           ./scripts/publish-build-status.sh building "Compiling the firmware" || true
+          rm -f progress-watcher.stop
           nohup ./scripts/watch-build-progress.sh > progress-watcher.log 2>&1 &
           echo "PROGRESS_WATCHER_PID=$!" >> "$GITHUB_ENV"
 
@@ -106,11 +107,19 @@ jobs:
         continue-on-error: true
 
       # Before any of the paths below publish a status of their own, so that a
-      # late progress update cannot overwrite the build result.
+      # late progress update cannot overwrite the build result. The watcher only
+      # stops between polls, so waiting for it to exit means any upload it had
+      # in flight has finished rather than racing the status published next.
       - name: Stop reporting compile progress
         if: always()
         run: |
+          touch progress-watcher.stop
           if [[ -n "${PROGRESS_WATCHER_PID:-}" ]]; then
+            for _ in $(seq 60); do
+              kill -0 "$PROGRESS_WATCHER_PID" 2> /dev/null || break
+              sleep 1
+            done
+            # Only reached if an upload hung well past its own timeout.
             kill "$PROGRESS_WATCHER_PID" 2> /dev/null || true
           fi
           if [[ -s progress-watcher.log ]]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,9 @@ jobs:
       run: npm ci
 
     - name: Run tests
-      run: npm test -- --watchAll=false
+      run: |
+        npm test -- --watchAll=false
+        node --test scripts/watch-build-progress.test.mjs
 
     - name: Build the app
       run: npm run build

--- a/infra/README.md
+++ b/infra/README.md
@@ -3,10 +3,10 @@
 Builds started from the [web builder](https://tomquist.github.io/esphome-b2500/)
 upload two objects to the `esphome-b2500-images` bucket:
 
-| Object                              | Purpose                                                              |
-| ----------------------------------- | -------------------------------------------------------------------- |
-| `firmware/<identifier>.zip`         | The password protected firmware archive.                             |
-| `firmware/<identifier>.status.json` | Build status the web builder polls (`building`, `success`, `error`). |
+| Object                              | Purpose                                                                                                                                |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `firmware/<identifier>.zip`         | The password protected firmware archive.                                                                                               |
+| `firmware/<identifier>.status.json` | Build status the web builder polls (`building`, `success`, `error`), including which step is running and how far along the compile is. |
 
 Both live under the same `firmware/` prefix so that a single public-read bucket
 policy covers them.

--- a/scripts/publish-build-status.sh
+++ b/scripts/publish-build-status.sh
@@ -10,6 +10,9 @@
 #   IDENTIFIER       build identifier from the repository dispatch (required)
 #   S3_BUCKET        target bucket (required)
 #   RUN_URL          link to this workflow run
+#   STEP             what the build is doing: preparing, compiling, packaging
+#   PROGRESS_DONE    compile units finished so far (with PROGRESS_TOTAL)
+#   PROGRESS_TOTAL   compile units the build expects in total
 #   FIRMWARE_URL     download URL of the firmware ZIP (success only)
 #   FIRMWARE_NAME    name of the firmware directory inside the ZIP
 #   ESPHOME_VERSION  ESPHome version the firmware was built with
@@ -28,15 +31,24 @@ jq -n \
   --arg status "$STATUS" \
   --arg identifier "$IDENTIFIER" \
   --arg message "$MESSAGE" \
+  --arg step "${STEP:-}" \
   --arg run_url "${RUN_URL:-}" \
   --arg firmware_url "${FIRMWARE_URL:-}" \
   --arg firmware_name "${FIRMWARE_NAME:-}" \
   --arg esphome_version "${ESPHOME_VERSION:-}" \
+  --argjson done "${PROGRESS_DONE:-0}" \
+  --argjson total "${PROGRESS_TOTAL:-0}" \
   --arg updated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   '{status: $status, identifier: $identifier, updated_at: $updated_at}
-    + ({run_url: $run_url, message: $message, firmware_url: $firmware_url,
-        firmware_name: $firmware_name, esphome_version: $esphome_version}
-       | with_entries(select(.value != "")))' > build-status.json
+    + ({run_url: $run_url, message: $message, step: $step,
+        firmware_url: $firmware_url, firmware_name: $firmware_name,
+        esphome_version: $esphome_version}
+       | with_entries(select(.value != "")))
+    + (if $done > 0 or $total > 0
+       then {progress: ({completed: $done}
+                        + (if $total > 0 then {total: $total} else {} end))}
+       else {} end)' \
+  > build-status.json
 
 cat build-status.json
 

--- a/scripts/watch-build-progress.sh
+++ b/scripts/watch-build-progress.sh
@@ -9,12 +9,16 @@
 # Counting both gives a progress fraction without having to parse the build log,
 # which belongs to the action running the compile rather than to us.
 #
-# Runs in the background alongside the build step and is killed once it
-# finishes, so it must never exit on a transient error.
+# Runs in the background alongside the build step. It stops when the stop file
+# appears, which it only checks between polls: an upload in flight always
+# finishes first, so a status it publishes can never land after the result the
+# workflow publishes once this has exited. It must never exit on a transient
+# error either.
 
 set -uo pipefail
 
 INTERVAL_SECONDS="${PROGRESS_INTERVAL_SECONDS:-15}"
+STOP_FILE="${PROGRESS_STOP_FILE:-progress-watcher.stop}"
 BUILD_ROOT="${PROGRESS_BUILD_ROOT:-.esphome/build}"
 PUBLISH="${PROGRESS_PUBLISH_COMMAND:-./scripts/publish-build-status.sh}"
 
@@ -32,7 +36,7 @@ count_expected_objects() {
 }
 
 last_completed=''
-while true; do
+while [[ ! -e "$STOP_FILE" ]]; do
   completed=$(count_objects)
   if [[ "$completed" -gt 0 && "$completed" != "$last_completed" ]]; then
     STEP=compiling \
@@ -41,5 +45,12 @@ while true; do
       "$PUBLISH" building "Compiling the firmware" > /dev/null || true
     last_completed="$completed"
   fi
-  sleep "$INTERVAL_SECONDS"
+  # Sleep in short ticks so that stopping does not have to wait out a full
+  # interval, and so that it is noticed here rather than during a publish.
+  for _ in $(seq "$INTERVAL_SECONDS"); do
+    if [[ -e "$STOP_FILE" ]]; then
+      break 2
+    fi
+    sleep 1
+  done
 done

--- a/scripts/watch-build-progress.sh
+++ b/scripts/watch-build-progress.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Publishes compile progress while the firmware builds, so the web builder can
+# show something better than a spinner for the several minutes the ESPHome
+# compile takes.
+#
+# ESP-IDF builds with ninja, which writes one object file per compile unit into
+# the build tree and declares every one of them in the generated build.ninja.
+# Counting both gives a progress fraction without having to parse the build log,
+# which belongs to the action running the compile rather than to us.
+#
+# Runs in the background alongside the build step and is killed once it
+# finishes, so it must never exit on a transient error.
+
+set -uo pipefail
+
+INTERVAL_SECONDS="${PROGRESS_INTERVAL_SECONDS:-15}"
+BUILD_ROOT="${PROGRESS_BUILD_ROOT:-.esphome/build}"
+PUBLISH="${PROGRESS_PUBLISH_COMMAND:-./scripts/publish-build-status.sh}"
+
+count_objects() {
+  find "$BUILD_ROOT" -type f \( -name '*.obj' -o -name '*.o' \) 2>/dev/null |
+    wc -l
+}
+
+# Every object file the generated ninja graphs plan to build. Bootloader and
+# app have separate graphs, so the counts are summed.
+count_expected_objects() {
+  find "$BUILD_ROOT" -type f -name 'build.ninja' -print0 2>/dev/null |
+    xargs -0 --no-run-if-empty grep -hcE '^build [^:]+\.(obj|o): ' 2>/dev/null |
+    awk '{ sum += $1 } END { print sum + 0 }'
+}
+
+last_completed=''
+while true; do
+  completed=$(count_objects)
+  if [[ "$completed" -gt 0 && "$completed" != "$last_completed" ]]; then
+    STEP=compiling \
+      PROGRESS_DONE="$completed" \
+      PROGRESS_TOTAL="$(count_expected_objects)" \
+      "$PUBLISH" building "Compiling the firmware" > /dev/null || true
+    last_completed="$completed"
+  fi
+  sleep "$INTERVAL_SECONDS"
+done

--- a/scripts/watch-build-progress.test.mjs
+++ b/scripts/watch-build-progress.test.mjs
@@ -1,0 +1,142 @@
+// The progress watcher publishes build status from a background process while
+// the firmware compiles, and the workflow stops it before publishing the build
+// result. If it could be stopped mid-upload, the upload it left in flight would
+// land a stale "building" status on top of that result and the web builder would
+// show compile progress for a finished build until it timed out.
+//
+//   node --test scripts/watch-build-progress.test.mjs
+
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const watcher = fileURLToPath(
+  new URL('./watch-build-progress.sh', import.meta.url)
+);
+const workspaces = [];
+
+after(() => {
+  for (const dir of workspaces) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** A build tree with `objects` compiled of `expected` the ninja graph declares. */
+const workspace = ({ objects, expected, publishSeconds = 0 }) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'watch-progress-'));
+  workspaces.push(dir);
+  const build = path.join(dir, '.esphome', 'build', 'b2500', 'build');
+  fs.mkdirSync(build, { recursive: true });
+
+  const edges = Array.from(
+    { length: expected },
+    (_, index) =>
+      `build src/file${index}.c.obj: C_COMPILER__idf src/file${index}.c`
+  );
+  // Link and archive edges must not be counted as compile units.
+  edges.push('build b2500.elf: CXX_EXECUTABLE_LINKER src/file0.c.obj');
+  fs.writeFileSync(path.join(build, 'build.ninja'), `${edges.join('\n')}\n`);
+
+  for (let index = 0; index < objects; index += 1) {
+    fs.writeFileSync(path.join(build, `file${index}.c.obj`), '');
+  }
+
+  // Records when each publish starts and finishes, so a publish that overlaps
+  // the stop can be told apart from one that started after it.
+  fs.writeFileSync(
+    path.join(dir, 'publish-stub.sh'),
+    [
+      '#!/usr/bin/env bash',
+      `echo "start $PROGRESS_DONE/$PROGRESS_TOTAL" >> "${path.join(dir, 'published.log')}"`,
+      `sleep ${publishSeconds}`,
+      `echo "end $PROGRESS_DONE/$PROGRESS_TOTAL" >> "${path.join(dir, 'published.log')}"`,
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+
+  return {
+    dir,
+    stopFile: path.join(dir, 'stop'),
+    published: () =>
+      fs.existsSync(path.join(dir, 'published.log'))
+        ? fs
+            .readFileSync(path.join(dir, 'published.log'), 'utf8')
+            .trim()
+            .split('\n')
+        : [],
+  };
+};
+
+const start = (space, { intervalSeconds = 1 } = {}) =>
+  spawn('bash', [watcher], {
+    cwd: space.dir,
+    env: {
+      ...process.env,
+      PROGRESS_INTERVAL_SECONDS: String(intervalSeconds),
+      PROGRESS_STOP_FILE: space.stopFile,
+      PROGRESS_PUBLISH_COMMAND: path.join(space.dir, 'publish-stub.sh'),
+    },
+    stdio: 'ignore',
+  });
+
+const waitFor = async (predicate, { timeoutMs = 15000 } = {}) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return false;
+};
+
+const exited = (child) => new Promise((resolve) => child.once('exit', resolve));
+
+test('publishes the compiled and expected object counts', async () => {
+  const space = workspace({ objects: 3, expected: 5 });
+  const child = start(space);
+
+  assert.ok(
+    await waitFor(() => space.published().length > 0),
+    'the watcher published nothing'
+  );
+  fs.writeFileSync(space.stopFile, '');
+  await exited(child);
+
+  assert.deepEqual(space.published(), ['start 3/5', 'end 3/5']);
+});
+
+test('finishes an upload that overlaps being stopped, and publishes nothing after', async () => {
+  const space = workspace({ objects: 2, expected: 4, publishSeconds: 3 });
+  const child = start(space);
+
+  assert.ok(
+    await waitFor(() => space.published().includes('start 2/4')),
+    'the watcher never started publishing'
+  );
+
+  // Stop while that upload is still in flight, the way the workflow does.
+  fs.writeFileSync(space.stopFile, '');
+  assert.deepEqual(
+    space.published(),
+    ['start 2/4'],
+    'the upload finished too early to test'
+  );
+
+  // More objects appear meanwhile: a watcher that kept polling would publish them.
+  const build = path.join(space.dir, '.esphome', 'build', 'b2500', 'build');
+  fs.writeFileSync(path.join(build, 'file2.c.obj'), '');
+
+  const code = await exited(child);
+
+  assert.equal(code, 0, 'the watcher did not exit cleanly');
+  assert.deepEqual(
+    space.published(),
+    ['start 2/4', 'end 2/4'],
+    'the in-flight upload must finish, and nothing may be published after the stop'
+  );
+});

--- a/src/components/BuildProgressDialog.tsx
+++ b/src/components/BuildProgressDialog.tsx
@@ -24,6 +24,7 @@ import { FormValues } from '../types';
 import { newIssueLink } from '../utils';
 import {
   BuildStatus,
+  BuildStep,
   BuildTimeoutError,
   buildListUrl,
   firmwareDownloadUrl,
@@ -47,6 +48,43 @@ interface BuildProgressDialogProps {
   config: FormValues;
   onClose: () => void;
 }
+
+const STEP_LABELS: Record<BuildStep, string> = {
+  preparing: 'Preparing the build',
+  compiling: 'Compiling the firmware',
+  packaging: 'Packaging the firmware',
+};
+
+const stepLabel = (status: BuildStatus | null): string => {
+  if (!status) {
+    return 'Waiting for the build to start';
+  }
+  return (
+    (status.step && STEP_LABELS[status.step]) ??
+    status.message ??
+    'Build running'
+  );
+};
+
+/** How much of the compile is done, or null while that is unknown. */
+const percentComplete = (status: BuildStatus | null): number | null => {
+  const progress = status?.progress;
+  if (!progress?.total) {
+    return null;
+  }
+  // Never show a full bar: the build is only done once the status says so.
+  return Math.min(99, (progress.completed / progress.total) * 100);
+};
+
+const compiledFiles = (status: BuildStatus | null): string | null => {
+  const progress = status?.progress;
+  if (!progress) {
+    return null;
+  }
+  return progress.total
+    ? `${progress.completed} of ${progress.total} files`
+    : `${progress.completed} files`;
+};
 
 const formatDuration = (seconds: number) => {
   const minutes = Math.floor(seconds / 60);
@@ -193,6 +231,8 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
   };
 
   const runLink = status?.runUrl ?? buildListUrl;
+  const buildPercent = percentComplete(status);
+  const buildFiles = compiledFiles(status);
   const downloadUrl = status?.firmwareUrl ?? firmwareDownloadUrl(identifier);
   const isBuilt = phase === 'ready' || (phase === 'error' && isRetryable);
   const activeStep = phase === 'building' ? 0 : phase === 'preparing' ? 1 : 2;
@@ -284,10 +324,16 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
               <StepLabel>Building your firmware</StepLabel>
               <StepContent>
                 <Typography variant="body2" gutterBottom>
-                  GitHub Actions is compiling your configuration. This usually
-                  takes 3 to 10 minutes - keep this dialog open.
+                  GitHub Actions is building your configuration. This usually
+                  takes around five minutes - keep this dialog open.
                 </Typography>
-                <LinearProgress sx={{ my: 1 }} />
+                <LinearProgress
+                  sx={{ my: 1 }}
+                  variant={
+                    buildPercent === null ? 'indeterminate' : 'determinate'
+                  }
+                  value={buildPercent ?? undefined}
+                />
                 {isStatusUnreachable && (
                   <Alert severity="warning" sx={{ my: 1 }}>
                     We cannot read the build status from this browser. Your
@@ -296,10 +342,9 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
                   </Alert>
                 )}
                 <Typography variant="caption" color="text.secondary">
-                  {status?.state === 'building'
-                    ? 'Build running'
-                    : 'Waiting for the build to start'}{' '}
-                  · {formatDuration(elapsedSeconds)} ·{' '}
+                  {stepLabel(status)}
+                  {buildFiles ? ` · ${buildFiles}` : ''} ·{' '}
+                  {formatDuration(elapsedSeconds)} ·{' '}
                   <Link href={runLink} target="_blank" rel="noopener">
                     View build log
                   </Link>
@@ -307,7 +352,7 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
               </StepContent>
             </Step>
             <Step>
-              <StepLabel>Preparing the firmware</StepLabel>
+              <StepLabel>Downloading the firmware</StepLabel>
               <StepContent>
                 <Typography variant="body2" gutterBottom>
                   Downloading and decrypting the firmware in your browser.

--- a/src/firmware/buildStatus.test.ts
+++ b/src/firmware/buildStatus.test.ts
@@ -27,10 +27,45 @@ describe('parseBuildStatus', () => {
       state: 'success',
       runUrl: 'https://github.com/run/1',
       message: undefined,
+      step: undefined,
+      progress: undefined,
       firmwareUrl: 'https://example.com/firmware.zip',
       firmwareName: 'b2500-esp32',
       esphomeVersion: '2026.8.1',
     });
+  });
+
+  it('reads the build step and its compile progress', () => {
+    const status = parseBuildStatus({
+      status: 'building',
+      step: 'compiling',
+      message: 'Compiling the firmware',
+      progress: { completed: 842, total: 1505 },
+    });
+
+    expect(status?.step).toBe('compiling');
+    expect(status?.progress).toEqual({ completed: 842, total: 1505 });
+  });
+
+  it('ignores steps and progress it does not understand', () => {
+    expect(
+      parseBuildStatus({ status: 'building', step: 'polishing' })?.step
+    ).toBeUndefined();
+    expect(
+      parseBuildStatus({ status: 'building', progress: { total: 1505 } })
+        ?.progress
+    ).toBeUndefined();
+  });
+
+  it('drops a total the build can never reach', () => {
+    // The workflow counts finished object files against the object files the
+    // ninja graph declares; a stale graph must not pin the bar below 100%.
+    const status = parseBuildStatus({
+      status: 'building',
+      progress: { completed: 1600, total: 1505 },
+    });
+
+    expect(status?.progress).toEqual({ completed: 1600, total: undefined });
   });
 
   it('returns null for documents it does not understand', () => {

--- a/src/firmware/buildStatus.ts
+++ b/src/firmware/buildStatus.ts
@@ -20,12 +20,24 @@ export const buildListUrl = 'https://github.com/tomquist/esphome-b2500/actions';
 
 export type BuildState = 'building' | 'success' | 'error';
 
+/** What a running build is currently doing. */
+export type BuildStep = 'preparing' | 'compiling' | 'packaging';
+
+export interface BuildProgress {
+  completed: number;
+  /** Absent until the build knows how much work there is. */
+  total?: number;
+}
+
 export interface BuildStatus {
   state: BuildState;
   /** Link to the GitHub Actions run that builds the firmware. */
   runUrl?: string;
   /** Error message, only set for failed builds. */
   message?: string;
+  step?: BuildStep;
+  /** Compile units finished so far, reported while compiling. */
+  progress?: BuildProgress;
   firmwareUrl?: string;
   /** Name of the firmware directory inside the ZIP, e.g. `b2500-esp32`. */
   firmwareName?: string;
@@ -44,8 +56,34 @@ const STATES: Record<string, BuildState> = {
   cancelled: 'error',
 };
 
+const STEPS: BuildStep[] = ['preparing', 'compiling', 'packaging'];
+
 const optionalString = (value: unknown): string | undefined =>
   typeof value === 'string' && value.length > 0 ? value : undefined;
+
+const optionalCount = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+
+const parseStep = (value: unknown): BuildStep | undefined => {
+  const step = optionalString(value)?.toLowerCase();
+  return STEPS.find((known) => known === step);
+};
+
+const parseProgress = (value: unknown): BuildProgress | undefined => {
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const completed = optionalCount(record.completed);
+  if (completed === undefined) {
+    return undefined;
+  }
+  const total = optionalCount(record.total);
+  // A total that cannot be reached would only ever show a stuck bar.
+  return { completed, total: total && total >= completed ? total : undefined };
+};
 
 /**
  * Parses the status document. Returns `null` for anything we don't understand
@@ -65,6 +103,8 @@ export const parseBuildStatus = (raw: unknown): BuildStatus | null => {
     state,
     runUrl: optionalString(record.run_url),
     message: optionalString(record.message),
+    step: parseStep(record.step),
+    progress: parseProgress(record.progress),
     firmwareUrl: optionalString(record.firmware_url),
     firmwareName: optionalString(record.firmware_name),
     esphomeVersion: optionalString(record.esphome_version),


### PR DESCRIPTION
The build dialog showed a single indeterminate bar for the whole build, which is close to six minutes of no feedback.

## Where the time actually goes

Measured on run [34253549356](https://github.com/tomquist/esphome-b2500/actions/runs/34253549356) (5m49s total):

| Phase | Duration |
| --- | --- |
| Checkout, deps, render | 44s |
| **`Build firmware` step** | **4m54s** |
| — docker image + esphome startup | 40s |
| — CMake configure | 60s |
| — **ninja compile `[1/1505]` → `[1502/1505]`** | **3m07s** |
| — size report, manifest | 7s |
| Zip, upload, publish | 11s |

The compile alone is 54% of the job, so step labels on their own would have left the long part just as opaque. The useful signal is inside it.

## How the progress is derived

ninja prints an exact `[N/M]` counter, but that output belongs to the `docker run` inside `esphome/build-action`, so we cannot tee it. The same information is on disk in the mounted workspace: ESP-IDF writes one object file per compile unit into the build tree, and the generated `build.ninja` declares every one of them.

`scripts/watch-build-progress.sh` counts both every 15s and publishes the ratio into the status document. It is started before the build step and stopped by the step after it. The workflow also names the step it is on (`preparing`, `compiling`, `packaging`).

The dialog then shows a determinate bar with "Compiling the firmware · 842 of 1505 files · 2:31", falling back to indeterminate whenever counts are not available — which includes the first ~100s of the build step, before any object exists.

## Guards

This touches the live build pipeline, so:

- **Progress cannot fail a build.** The milestone publishes are `|| true` and the watcher swallows its own errors; a status upload hiccup must not kill a five-minute compile. The terminal success/error publishes stay strict, as before.
- **Progress cannot overwrite a result.** The watcher is stopped in an `if: always()` step placed before every path that publishes a status, so a late update cannot clobber success or error.
- **The bar does not lie.** A `total` below the count already built is dropped rather than shown, so a stale ninja graph cannot pin the bar short of the end, and it stops at 99% until the build itself reports done.
- The watcher's log is echoed by the stop step, so a silent failure is diagnosable from the run.

## Cost

3 → 17 S3 writes per build (4 milestones, ~12 watcher updates, 1 zip upload). At ~770 builds/month and list prices that is **+$0.054/month**; total S3 requests for the whole flow come to about $0.09/month. Egress (~10 GB/month) sits inside the free allowance, and storage stays under a GB because archives are already expired within a few days. `PROGRESS_INTERVAL_SECONDS` is the knob if that ever needs trimming.

## Verification

- 25 unit tests, including the parser dropping an unreachable total and ignoring unknown steps.
- The watcher was run against a simulated ninja tree: counts objects, excludes link and archive edges, publishes only on change.
- A browser run drove the real dialog through `preparing → compiling → packaging → ready`, asserting the bar is genuinely indeterminate (no `aria-valuenow`) before counts arrive and reports 56% for 842/1505.

Old status documents remain valid: they simply carry no `step` or `progress`, and the dialog falls back to its previous behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHRfPYy5iRWAUC9piMNy7G

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHRfPYy5iRWAUC9piMNy7G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build progress now shows the current stage: preparing, compiling, or packaging.
  * Compilation displays determinate progress and the number of completed files when available.
  * The firmware download step is clearly labeled in the build dialog.
  * Build status updates now provide clearer stage and progress information.

* **Documentation**
  * Updated build-status documentation to describe stages and compilation progress.

* **Tests**
  * Added coverage for build-stage and progress parsing, including invalid values.
  * Added coverage for progress reporting during and after compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->