### PR TITLE
Stream build output to the web builder during compilation

### DIFF
--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -35,6 +35,10 @@ jobs:
       # context and a pick of ESPHome's validation behaviour.
       ESPHOME_VERSION: '2026.8.1'
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      # Everything before the compile is the runner installing Python, Node and
+      # the AWS action - not what someone waiting on their firmware wants to
+      # read, so the published output starts where the build does.
+      LOG_START_AT: '^##\[group\]Run esphome/build-action'
     permissions:
       contents: read
       # So the build can read its own log back and forward the compiler's
@@ -111,12 +115,14 @@ jobs:
       - name: Report compile progress
         env:
           STEP: compiling
-          # Inherited by the watcher, which reads this job's log through the
-          # API to publish the compiler's output alongside the progress.
+          # Inherited by the watcher, which reads this job's log back through
+          # the API. Scoped to the steps that need it rather than set on the
+          # job, so the third-party build action never sees it.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./scripts/publish-build-status.sh building "Compiling the firmware" || true
-          rm -f progress-watcher.stop job-log-unavailable job-log-unavailable.misses
+          rm -f progress-watcher.stop job-log-unavailable job-log-unavailable.misses \
+            build-log.published build-log.count
           nohup ./scripts/watch-build-progress.sh > progress-watcher.log 2>&1 &
           echo "PROGRESS_WATCHER_PID=$!" >> "$GITHUB_ENV"
 
@@ -153,24 +159,30 @@ jobs:
             echo "::endgroup::"
           fi
 
-      # The compile runs inside esphome/build-action, so the only place its
-      # output exists is this job's log - which the page cannot read, because
-      # the run is only linked from it. Reading the log back turns "the build
-      # failed" into something the requester can act on. Collected here rather
-      # than where it is published: every step that runs in between writes to
-      # the same log, and would push the compiler out of the tail.
-      - name: Collect the build output
-        if: steps.esphome-build.outcome == 'failure'
+      # The watcher stopped between polls, so the last seconds of the compile -
+      # on a failed build, the error itself - are not published yet. Runs after
+      # the watcher has exited so there is only ever one writer, and before any
+      # terminal status so the page is never told about a segment that is not
+      # in the bucket yet.
+      - name: Publish the rest of the build output
+        if: always()
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LOG_TAIL_LINES: '200'
-          LOG_MAX_BYTES: '24000'
           LOG_END_AT_ERROR: 'true'
           # Not the file the watcher may have written off: whatever stopped it
-          # reporting during the compile is worth one more try for the failure.
-          LOG_DISABLED_FILE: job-log-failure-unavailable
-        run: ./scripts/fetch-job-log.sh > build-failure.log || true
+          # reporting during the compile is worth one more try at the end.
+          LOG_DISABLED_FILE: job-log-final-unavailable
+        run: |
+          segments="$(./scripts/publish-build-log.sh)"
+          # The start marker is a runner convention rather than something we
+          # control, and while the build runs a stream that never started is
+          # better than one that shifts under the page. Here it is over, so
+          # nothing can shift: publish the whole log rather than none of it.
+          if [[ "$segments" == "0" ]]; then
+            segments="$(LOG_START_AT='' ./scripts/publish-build-log.sh)"
+          fi
+          echo "LOG_SEGMENTS=$segments" >> "$GITHUB_ENV"
 
       # Logs on a public repository are world readable, and the config holds
       # the requester's SSID, MQTT broker and username. The redacted form keeps
@@ -238,15 +250,12 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LOG_TAIL_LINES: '200'
-          LOG_MAX_BYTES: '24000'
           LOG_END_AT_ERROR: 'true'
           LOG_DISABLED_FILE: job-log-failure-unavailable
         run: |
-          # Only for a failure that is not the compile's: that one was
-          # collected above, where the compiler still had the last word.
-          if [[ ! -s build-failure.log ]]; then
-            ./scripts/fetch-job-log.sh > build-failure.log || true
-          fi
-          BUILD_LOG_FILE=build-failure.log ./scripts/publish-build-status.sh error \
+          # A failure after the compile - packaging, or the upload - has said
+          # something since the flush above, and this is the last chance to
+          # publish it.
+          export LOG_SEGMENTS="$(./scripts/publish-build-log.sh)"
+          ./scripts/publish-build-status.sh error \
             "The firmware build failed. Please check the build log and open an issue with your configuration."

--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -37,6 +37,9 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     permissions:
       contents: read
+      # So the build can read its own log back and forward the compiler's
+      # output to the page waiting for it. See scripts/fetch-job-log.sh.
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -108,9 +111,12 @@ jobs:
       - name: Report compile progress
         env:
           STEP: compiling
+          # Inherited by the watcher, which reads this job's log through the
+          # API to publish the compiler's output alongside the progress.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./scripts/publish-build-status.sh building "Compiling the firmware" || true
-          rm -f progress-watcher.stop
+          rm -f progress-watcher.stop job-log-unavailable job-log-unavailable.misses
           nohup ./scripts/watch-build-progress.sh > progress-watcher.log 2>&1 &
           echo "PROGRESS_WATCHER_PID=$!" >> "$GITHUB_ENV"
 
@@ -146,6 +152,25 @@ jobs:
             cat progress-watcher.log
             echo "::endgroup::"
           fi
+
+      # The compile runs inside esphome/build-action, so the only place its
+      # output exists is this job's log - which the page cannot read, because
+      # the run is only linked from it. Reading the log back turns "the build
+      # failed" into something the requester can act on. Collected here rather
+      # than where it is published: every step that runs in between writes to
+      # the same log, and would push the compiler out of the tail.
+      - name: Collect the build output
+        if: steps.esphome-build.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LOG_TAIL_LINES: '200'
+          LOG_MAX_BYTES: '24000'
+          LOG_END_AT_ERROR: 'true'
+          # Not the file the watcher may have written off: whatever stopped it
+          # reporting during the compile is worth one more try for the failure.
+          LOG_DISABLED_FILE: job-log-failure-unavailable
+        run: ./scripts/fetch-job-log.sh > build-failure.log || true
 
       # Logs on a public repository are world readable, and the config holds
       # the requester's SSID, MQTT broker and username. The redacted form keeps
@@ -211,6 +236,17 @@ jobs:
       - name: Publish build failure
         if: failure()
         continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LOG_TAIL_LINES: '200'
+          LOG_MAX_BYTES: '24000'
+          LOG_END_AT_ERROR: 'true'
+          LOG_DISABLED_FILE: job-log-failure-unavailable
         run: |
-          ./scripts/publish-build-status.sh error \
+          # Only for a failure that is not the compile's: that one was
+          # collected above, where the compiler still had the last word.
+          if [[ ! -s build-failure.log ]]; then
+            ./scripts/fetch-job-log.sh > build-failure.log || true
+          fi
+          BUILD_LOG_FILE=build-failure.log ./scripts/publish-build-status.sh error \
             "The firmware build failed. Please check the build log and open an issue with your configuration."

--- a/.github/workflows/build-esphome.yml
+++ b/.github/workflows/build-esphome.yml
@@ -38,7 +38,7 @@ jobs:
       # Everything before the compile is the runner installing Python, Node and
       # the AWS action - not what someone waiting on their firmware wants to
       # read, so the published output starts where the build does.
-      LOG_START_AT: '^##\[group\]Run esphome/build-action'
+      LOG_START_AT: '##[group]Run esphome/build-action'
     permissions:
       contents: read
       # So the build can read its own log back and forward the compiler's

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,15 +1,24 @@
 # Firmware bucket configuration
 
 Builds started from the [web builder](https://tomquist.github.io/esphome-b2500/)
-upload two objects to the `esphome-b2500-images` bucket:
+upload three kinds of object to the `esphome-b2500-images` bucket:
 
 | Object                              | Purpose                                                                                                                                |
 | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `firmware/<identifier>.zip.enc`     | The firmware archive, sealed to the requesting page's key (see below).                                                                 |
-| `firmware/<identifier>.status.json` | Build status the web builder polls (`building`, `success`, `error`), including which step is running, how far along the compile is, and the tail of the build output. |
+| `firmware/<identifier>.status.json` | Build status the web builder polls (`building`, `success`, `error`), including which step is running, how far along the compile is, and how many build output segments exist. |
+| `firmware/<identifier>.log.<n>`     | The build output, numbered from zero. Each segment holds only what the compiler printed since the one before it.                       |
 
-Both live under the same `firmware/` prefix so that a single public-read bucket
-policy covers them.
+All of them live under the same `firmware/` prefix so that a single public-read
+bucket policy - and the expiry rule below - covers them.
+
+S3 has no append: an object is replaced whole or not at all. A log published as
+one growing object would therefore have to be re-uploaded, and re-read, every
+few seconds for the length of a build. Publishing it as a run of immutable
+segments instead means every byte is uploaded once and downloaded once. The page
+learns how many exist from `log_segments` in the status document, which is
+written after the segment it counts, so a segment it knows about is always one
+it can fetch. See [`scripts/publish-build-log.sh`](../scripts/publish-build-log.sh).
 
 ## CORS
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,7 +6,7 @@ upload two objects to the `esphome-b2500-images` bucket:
 | Object                              | Purpose                                                                                                                                |
 | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `firmware/<identifier>.zip.enc`     | The firmware archive, sealed to the requesting page's key (see below).                                                                 |
-| `firmware/<identifier>.status.json` | Build status the web builder polls (`building`, `success`, `error`), including which step is running and how far along the compile is. |
+| `firmware/<identifier>.status.json` | Build status the web builder polls (`building`, `success`, `error`), including which step is running, how far along the compile is, and the tail of the build output. |
 
 Both live under the same `firmware/` prefix so that a single public-read bucket
 policy covers them.

--- a/scripts/fetch-job-log.sh
+++ b/scripts/fetch-job-log.sh
@@ -30,9 +30,9 @@
 #   GITHUB_RUN_ID       the run whose job log to read (required)
 #   GITHUB_RUN_ATTEMPT  which attempt of that run, defaults to 1
 #   GITHUB_JOB          job id in the workflow file, used to pick the job
-#   LOG_START_AT        drop everything up to and including the last line
-#                       matching this regex, and print nothing until some line
-#                       does match
+#   LOG_START_AT        drop everything up to and including the last line that
+#                       starts with this text, and print nothing until some
+#                       line does. A literal prefix, not a pattern - see below
 #   LOG_END_AT_ERROR    stop at the first `##[error]` line, keeping it
 #   LOG_TAIL_LINES      keep only this many lines from the end
 #   LOG_MAX_BYTES       keep only this many bytes from the end
@@ -85,9 +85,17 @@ clean_log() {
     # prefix starts the moment the marker appeared - which corrupts every
     # segment published after it. No log is a feature that quietly did not
     # happen; a shifting one is a log nobody can read.
+    #
+    # Compared as a literal prefix rather than matched as a regex. `awk -v`
+    # processes escape sequences in the value it assigns, and the two awks in
+    # play disagree about what survives: gawk turns `\[group\]` into `[group]`,
+    # which is then a character class that cannot match the `[group]` it was
+    # written to find, while mawk leaves the backslashes alone and matches.
+    # The marker is a fixed string, so comparing it as one is both what we mean
+    # and the same thing everywhere.
     { if [[ -n "${LOG_START_AT:-}" ]]; then
-        awk -v pattern="$LOG_START_AT" '
-          { line[NR] = $0; if ($0 ~ pattern) { start = NR } }
+        awk -v prefix="$LOG_START_AT" '
+          { line[NR] = $0; if (substr($0, 1, length(prefix)) == prefix) { start = NR } }
           END { if (start) for (i = start + 1; i <= NR; i++) print line[i] }'
       else
         cat

--- a/scripts/fetch-job-log.sh
+++ b/scripts/fetch-job-log.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# Prints a cleaned tail of this workflow job's own log.
+#
+# The compile runs inside esphome/build-action, so its output belongs to that
+# step rather than to us: there is no file to tail and no pipe to tee. The
+# Actions API does serve a job's log while the job is still running, though, so
+# reading our own log back is the one way to get the compiler's output out of
+# the runner and in front of the person waiting for the build. The watcher
+# publishes what this prints every few seconds, and the failure path publishes
+# a longer tail ending at the error.
+#
+# Everything here is best effort. A build that cannot read its own log still
+# reports progress and still reports failure, only without the output - so no
+# path may exit non-zero in a way that fails the step that called it, and a
+# refusal that will not go away (a revoked token, an exhausted rate limit) must
+# stop us from asking again for the rest of the build.
+#
+# Secrets never reach this: render.js registers them with `::add-mask::` before
+# the compile starts, so the log the API returns already has them replaced.
+#
+# Usage: fetch-job-log.sh
+#
+# Environment:
+#   GITHUB_TOKEN        token with `actions: read` (required)
+#   GITHUB_REPOSITORY   owner/repo (required)
+#   GITHUB_RUN_ID       the run whose job log to read (required)
+#   GITHUB_RUN_ATTEMPT  which attempt of that run, defaults to 1
+#   GITHUB_JOB          job id in the workflow file, used to pick the job
+#   LOG_TAIL_LINES      how many lines to print
+#   LOG_MAX_BYTES       hard cap on what is printed, applied after the lines
+#   LOG_END_AT_ERROR    stop at the first `##[error]` line, keeping it
+#   LOG_SOURCE_FILE     read this instead of the API (used by the tests)
+#   LOG_JOB_ID_FILE     caches the resolved job id between calls
+#   LOG_DISABLED_FILE   marks the log as unreadable, so we stop asking
+
+set -uo pipefail
+
+TAIL_LINES="${LOG_TAIL_LINES:-40}"
+MAX_BYTES="${LOG_MAX_BYTES:-8000}"
+API_URL="${GITHUB_API_URL:-https://api.github.com}"
+JOB_ID_FILE="${LOG_JOB_ID_FILE:-job-log-id}"
+DISABLED_FILE="${LOG_DISABLED_FILE:-job-log-unavailable}"
+MISSES_FILE="${DISABLED_FILE}.misses"
+# A log that is not there yet reads exactly like one we will never be allowed
+# to read, so give it a few tries before giving up on it for good.
+MAX_MISSES="${LOG_MAX_MISSES:-5}"
+
+ESC=$(printf '\033')
+
+# Turns a downloaded job log into something worth showing: no timestamps, no
+# terminal escapes, and no runner command markers, which are noise everywhere
+# except on the error that ended the build.
+clean_log() {
+  sed -E \
+    -e 's/\r$//' \
+    -e 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z //' \
+    -e "s/${ESC}\\[[0-9;?]*[a-zA-Z]//g" \
+    -e "s/${ESC}[()][A-B0-2]//g" \
+    -e "s/${ESC}\\][^${ESC}]*(\\a|${ESC}\\\\)//g" |
+    # The failing step is the last thing the log has to say that anyone cares
+    # about; whatever the workflow does afterwards (publishing this log, among
+    # other things) would only push it out of the tail.
+    { if [[ -n "${LOG_END_AT_ERROR:-}" ]]; then
+        awk '{ print } /^##\[error\]/ { exit }'
+      else
+        cat
+      fi; } |
+    sed -E \
+      -e 's/^##\[error\]/ERROR: /' \
+      -e 's/^##\[warning\]/WARNING: /' |
+    grep -v '^##\[' |
+    tail -n "$TAIL_LINES" |
+    tail -c "$MAX_BYTES"
+}
+
+if [[ -n "${LOG_SOURCE_FILE:-}" ]]; then
+  [[ -r "$LOG_SOURCE_FILE" ]] || exit 1
+  clean_log < "$LOG_SOURCE_FILE"
+  exit 0
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" || -z "${GITHUB_REPOSITORY:-}" || -z "${GITHUB_RUN_ID:-}" ]]; then
+  exit 1
+fi
+if [[ -e "$DISABLED_FILE" ]]; then
+  exit 1
+fi
+
+# Prints the response status, writes the body to $2.
+api_get() {
+  curl -sS --max-time 60 -o "$2" -w '%{http_code} %{redirect_url}' \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$1" 2> /dev/null
+}
+
+give_up() {
+  touch "$DISABLED_FILE" 2> /dev/null || true
+  exit 1
+}
+
+# 404 while the job runs is normal enough to retry; the same answer over and
+# over is not.
+missed() {
+  local misses
+  misses=$(( $(cat "$MISSES_FILE" 2> /dev/null || echo 0) + 1 ))
+  echo "$misses" > "$MISSES_FILE" 2> /dev/null || true
+  if [[ "$misses" -ge "$MAX_MISSES" ]]; then
+    give_up
+  fi
+  exit 1
+}
+
+body=$(mktemp)
+trap 'rm -f "$body"' EXIT
+
+job_id=''
+if [[ -s "$JOB_ID_FILE" ]]; then
+  job_id=$(< "$JOB_ID_FILE")
+fi
+
+if [[ -z "$job_id" ]]; then
+  read -r status _ < <(api_get \
+    "$API_URL/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/${GITHUB_RUN_ATTEMPT:-1}/jobs?per_page=100" \
+    "$body")
+  case "$status" in
+    200) ;;
+    401 | 403 | 429) give_up ;;
+    *) missed ;;
+  esac
+  # This job by name, the one that is running, then whatever came first: a
+  # workflow with a single job resolves on the first of those every time.
+  job_id=$(jq -r --arg name "${GITHUB_JOB:-}" '
+    (.jobs // []) as $jobs
+    | [ ($jobs[] | select(.name == $name)),
+        ($jobs[] | select(.status == "in_progress")),
+        $jobs[] ]
+    | (first(.[].id) // empty)' "$body" 2> /dev/null)
+  [[ "$job_id" =~ ^[0-9]+$ ]] || missed
+  echo "$job_id" > "$JOB_ID_FILE" 2> /dev/null || true
+fi
+
+# The log itself lives in blob storage behind a signed redirect. Following it
+# with the Authorization header still attached makes the storage reject the
+# request for carrying two credentials, so the redirect is fetched bare.
+read -r status redirect < <(api_get \
+  "$API_URL/repos/$GITHUB_REPOSITORY/actions/jobs/$job_id/logs" "$body")
+case "$status" in
+  200) ;;
+  30*)
+    [[ -n "${redirect:-}" ]] || missed
+    status=$(curl -sS --max-time 120 -o "$body" -w '%{http_code}' "$redirect" 2> /dev/null)
+    [[ "$status" == "200" ]] || missed
+    ;;
+  401 | 403 | 429) give_up ;;
+  *) missed ;;
+esac
+
+[[ -s "$body" ]] || missed
+rm -f "$MISSES_FILE" 2> /dev/null || true
+# A pipeline that stopped at the error, or that filtered everything out,
+# is not a failure to report: the callers judge this by what it printed.
+clean_log < "$body"
+exit 0

--- a/scripts/fetch-job-log.sh
+++ b/scripts/fetch-job-log.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 #
-# Prints a cleaned tail of this workflow job's own log.
+# Prints this workflow job's own log, cleaned.
 #
 # The compile runs inside esphome/build-action, so its output belongs to that
-# step rather than to us: there is no file to tail and no pipe to tee. The
-# Actions API does serve a job's log while the job is still running, though, so
-# reading our own log back is the one way to get the compiler's output out of
-# the runner and in front of the person waiting for the build. The watcher
-# publishes what this prints every few seconds, and the failure path publishes
-# a longer tail ending at the error.
+# step: there is no file to tail and no pipe to tee. The Actions API does serve
+# a job's log while the job is still running, so reading our own log back is the
+# one way to get the compiler's output out of the runner and in front of the
+# person waiting for the build. publish-build-log.sh turns what this prints into
+# the segments the web builder downloads.
+#
+# Prints the whole log by default, because the caller publishes it as a growing
+# prefix and needs the same bytes every time. `LOG_TAIL_LINES` and
+# `LOG_MAX_BYTES` are for callers that want an excerpt instead.
 #
 # Everything here is best effort. A build that cannot read its own log still
 # reports progress and still reports failure, only without the output - so no
@@ -27,17 +30,21 @@
 #   GITHUB_RUN_ID       the run whose job log to read (required)
 #   GITHUB_RUN_ATTEMPT  which attempt of that run, defaults to 1
 #   GITHUB_JOB          job id in the workflow file, used to pick the job
-#   LOG_TAIL_LINES      how many lines to print
-#   LOG_MAX_BYTES       hard cap on what is printed, applied after the lines
+#   LOG_START_AT        drop everything up to and including the last line
+#                       matching this regex, and print nothing until some line
+#                       does match
 #   LOG_END_AT_ERROR    stop at the first `##[error]` line, keeping it
+#   LOG_TAIL_LINES      keep only this many lines from the end
+#   LOG_MAX_BYTES       keep only this many bytes from the end
 #   LOG_SOURCE_FILE     read this instead of the API (used by the tests)
 #   LOG_JOB_ID_FILE     caches the resolved job id between calls
 #   LOG_DISABLED_FILE   marks the log as unreadable, so we stop asking
 
 set -uo pipefail
 
-TAIL_LINES="${LOG_TAIL_LINES:-40}"
-MAX_BYTES="${LOG_MAX_BYTES:-8000}"
+source_copy=$(mktemp)
+trap 'rm -f "$source_copy"' EXIT
+
 API_URL="${GITHUB_API_URL:-https://api.github.com}"
 JOB_ID_FILE="${LOG_JOB_ID_FILE:-job-log-id}"
 DISABLED_FILE="${LOG_DISABLED_FILE:-job-log-unavailable}"
@@ -47,20 +54,47 @@ MISSES_FILE="${DISABLED_FILE}.misses"
 MAX_MISSES="${LOG_MAX_MISSES:-5}"
 
 ESC=$(printf '\033')
+BOM=$(printf '\357\273\277')
 
-# Turns a downloaded job log into something worth showing: no timestamps, no
-# terminal escapes, and no runner command markers, which are noise everywhere
-# except on the error that ended the build.
+# Turns a downloaded job log into something worth showing: no byte order mark,
+# no timestamps, no terminal escapes, and no runner command markers, which are
+# noise everywhere except on the error that ended the build.
+#
+# Takes the log as a file rather than on stdin because the first thing it has to
+# know is whether the last line has its newline yet. A line still being written
+# is a line that will read differently next time - and since sed and awk end
+# their output with a newline whether the input had one or not, that can only be
+# told from the bytes as they arrived.
 clean_log() {
+  local source="$1"
+  { if [[ -n "$(tail -c 1 "$source")" ]]; then
+      head -n -1 "$source"
+    else
+      cat "$source"
+    fi; } |
   sed -E \
+    -e "1s/^${BOM}//" \
     -e 's/\r$//' \
     -e 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z //' \
     -e "s/${ESC}\\[[0-9;?]*[a-zA-Z]//g" \
     -e "s/${ESC}[()][A-B0-2]//g" \
     -e "s/${ESC}\\][^${ESC}]*(\\a|${ESC}\\\\)//g" |
+    # Everything before the compile is the runner installing things. Nothing at
+    # all until the marker shows up: the caller publishes this as a growing
+    # prefix of itself, and falling back to the whole log would move where that
+    # prefix starts the moment the marker appeared - which corrupts every
+    # segment published after it. No log is a feature that quietly did not
+    # happen; a shifting one is a log nobody can read.
+    { if [[ -n "${LOG_START_AT:-}" ]]; then
+        awk -v pattern="$LOG_START_AT" '
+          { line[NR] = $0; if ($0 ~ pattern) { start = NR } }
+          END { if (start) for (i = start + 1; i <= NR; i++) print line[i] }'
+      else
+        cat
+      fi; } |
     # The failing step is the last thing the log has to say that anyone cares
     # about; whatever the workflow does afterwards (publishing this log, among
-    # other things) would only push it out of the tail.
+    # other things) would only push it out of view.
     { if [[ -n "${LOG_END_AT_ERROR:-}" ]]; then
         awk '{ print } /^##\[error\]/ { exit }'
       else
@@ -70,13 +104,15 @@ clean_log() {
       -e 's/^##\[error\]/ERROR: /' \
       -e 's/^##\[warning\]/WARNING: /' |
     grep -v '^##\[' |
-    tail -n "$TAIL_LINES" |
-    tail -c "$MAX_BYTES"
+    { if [[ -n "${LOG_TAIL_LINES:-}" ]]; then tail -n "$LOG_TAIL_LINES"; else cat; fi; } |
+    { if [[ -n "${LOG_MAX_BYTES:-}" ]]; then tail -c "$LOG_MAX_BYTES"; else cat; fi; }
 }
 
 if [[ -n "${LOG_SOURCE_FILE:-}" ]]; then
   [[ -r "$LOG_SOURCE_FILE" ]] || exit 1
-  clean_log < "$LOG_SOURCE_FILE"
+  # A process substitution is not seekable, so give `tail -c 1` a real file.
+  cp "$LOG_SOURCE_FILE" "$source_copy" 2> /dev/null || exit 1
+  clean_log "$source_copy"
   exit 0
 fi
 
@@ -87,7 +123,7 @@ if [[ -e "$DISABLED_FILE" ]]; then
   exit 1
 fi
 
-# Prints the response status, writes the body to $2.
+# Prints the response status and any redirect target, writes the body to $2.
 api_get() {
   curl -sS --max-time 60 -o "$2" -w '%{http_code} %{redirect_url}' \
     -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -114,7 +150,7 @@ missed() {
 }
 
 body=$(mktemp)
-trap 'rm -f "$body"' EXIT
+trap 'rm -f "$body" "$source_copy"' EXIT
 
 job_id=''
 if [[ -s "$JOB_ID_FILE" ]]; then
@@ -160,7 +196,7 @@ esac
 
 [[ -s "$body" ]] || missed
 rm -f "$MISSES_FILE" 2> /dev/null || true
-# A pipeline that stopped at the error, or that filtered everything out,
-# is not a failure to report: the callers judge this by what it printed.
-clean_log < "$body"
+# A pipeline that stopped at the error, or that filtered everything out, is not
+# a failure to report: the callers judge this by what it printed.
+clean_log "$body"
 exit 0

--- a/scripts/fetch-job-log.sh
+++ b/scripts/fetch-job-log.sh
@@ -60,6 +60,12 @@ BOM=$(printf '\357\273\277')
 # no timestamps, no terminal escapes, and no runner command markers, which are
 # noise everywhere except on the error that ended the build.
 #
+# The escape pattern is the whole CSI form - parameter bytes 0x30-0x3F, then
+# intermediates 0x20-0x2F, then a final byte 0x40-0x7E - rather than the colour
+# codes alone. Docker's buildx output inside the compile step writes forms like
+# `ESC[1:2m` that a digits-and-semicolons pattern walks straight past, and what
+# it leaves behind is rendered as text on the page.
+#
 # Takes the log as a file rather than on stdin because the first thing it has to
 # know is whether the last line has its newline yet. A line still being written
 # is a line that will read differently next time - and since sed and awk end
@@ -76,7 +82,7 @@ clean_log() {
     -e "1s/^${BOM}//" \
     -e 's/\r$//' \
     -e 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z //' \
-    -e "s/${ESC}\\[[0-9;?]*[a-zA-Z]//g" \
+    -e "s,${ESC}\\[[0-?]*[ -/]*[@-~],,g" \
     -e "s/${ESC}[()][A-B0-2]//g" \
     -e "s/${ESC}\\][^${ESC}]*(\\a|${ESC}\\\\)//g" |
     # Everything before the compile is the runner installing things. Nothing at

--- a/scripts/fetch-job-log.test.mjs
+++ b/scripts/fetch-job-log.test.mjs
@@ -88,7 +88,7 @@ test('ends the failure tail at the error, not at what the workflow did next', ()
 
 test('starts where the compile does', () => {
   const printed = run(jobLog(compile), {
-    LOG_START_AT: '^##\\[group\\]Run esphome/build-action',
+    LOG_START_AT: '##[group]Run esphome/build-action',
   });
 
   assert.ok(
@@ -101,9 +101,21 @@ test('prints nothing until the start marker is there', () => {
   // Falling back to the whole log would move where the published prefix
   // starts the moment the marker appeared, and every segment after that
   // would be a slice of a different log.
-  const printed = run(jobLog(compile), { LOG_START_AT: '^nothing matches$' });
+  const printed = run(jobLog(compile), { LOG_START_AT: 'nothing matches' });
 
   assert.equal(printed, '');
+});
+
+test('matches the start marker literally, not as a pattern', () => {
+  // `awk -v` eats escape sequences, and gawk and mawk disagree about which
+  // survive: a regex written to find `[group]` reaches gawk as a character
+  // class that cannot match it. The runner has gawk, so this passing under
+  // whichever awk is to hand is the point.
+  assert.equal(
+    run(jobLog(compile), { LOG_START_AT: '##[group]Run esphome/build-.ction' }),
+    '',
+    'the marker was matched as a pattern rather than compared as text'
+  );
 });
 
 test('holds back a line the runner has not finished writing', () => {

--- a/scripts/fetch-job-log.test.mjs
+++ b/scripts/fetch-job-log.test.mjs
@@ -118,6 +118,20 @@ test('matches the start marker literally, not as a pattern', () => {
   );
 });
 
+test('strips the whole CSI form, not just colour codes', () => {
+  // Docker's buildx output inside the compile writes sub-parameter forms like
+  // `ESC[1:2m`, which a digits-and-semicolons pattern walks past - and what it
+  // leaves behind is rendered as text on the page.
+  const escape = String.fromCharCode(27);
+  const printed = run(
+    jobLog([
+      `${escape}[31mred${escape}[0m ${escape}[1:2mfancy${escape}[0m ${escape}[38;2;1;2;3mtruecolor${escape}[0m`,
+    ])
+  );
+
+  assert.equal(printed, 'red fancy truecolor\n');
+});
+
 test('holds back a line the runner has not finished writing', () => {
   // sed and awk end their output with a newline whether the input had one or
   // not, so a partial line would otherwise look finished - and read

--- a/scripts/fetch-job-log.test.mjs
+++ b/scripts/fetch-job-log.test.mjs
@@ -86,6 +86,54 @@ test('ends the failure tail at the error, not at what the workflow did next', ()
   assert.ok(printed.trimEnd().endsWith('exit code 1.'));
 });
 
+test('starts where the compile does', () => {
+  const printed = run(jobLog(compile), {
+    LOG_START_AT: '^##\\[group\\]Run esphome/build-action',
+  });
+
+  assert.ok(
+    printed.startsWith('INFO Compiling app...'),
+    `kept the runner setup that comes before the compile: ${printed}`
+  );
+});
+
+test('prints nothing until the start marker is there', () => {
+  // Falling back to the whole log would move where the published prefix
+  // starts the moment the marker appeared, and every segment after that
+  // would be a slice of a different log.
+  const printed = run(jobLog(compile), { LOG_START_AT: '^nothing matches$' });
+
+  assert.equal(printed, '');
+});
+
+test('holds back a line the runner has not finished writing', () => {
+  // sed and awk end their output with a newline whether the input had one or
+  // not, so a partial line would otherwise look finished - and read
+  // differently on the next fetch, after the rest of it arrived.
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'job-log-'));
+  directories.push(directory);
+  const file = path.join(directory, 'job.log');
+  const stamp = '2026-09-09T10:00:00.1234567Z ';
+  fs.writeFileSync(file, `${stamp}[1/2] done\r\n${stamp}[2/2] half`);
+
+  assert.equal(run(file), '[1/2] done\n');
+
+  fs.appendFileSync(file, '-written\r\n');
+  assert.equal(run(file), '[1/2] done\n[2/2] half-written\n');
+});
+
+test('holds back a line cut inside its timestamp', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'job-log-'));
+  directories.push(directory);
+  const file = path.join(directory, 'job.log');
+  fs.writeFileSync(
+    file,
+    '2026-09-09T10:00:00.1234567Z done\r\n2026-09-09T10:0'
+  );
+
+  assert.equal(run(file), 'done\n');
+});
+
 test('keeps only the end of a long log', () => {
   const source = jobLog(
     Array.from({ length: 500 }, (_, index) => `line ${index}`)

--- a/scripts/fetch-job-log.test.mjs
+++ b/scripts/fetch-job-log.test.mjs
@@ -1,0 +1,137 @@
+// The build's own job log is the only place the compiler's output exists, and
+// what this prints goes straight into the status document the web builder
+// shows. These cover the shaping of it: timestamps and terminal escapes off,
+// runner markers out of the way, and the failure tail ending at the error
+// rather than at whatever the workflow did afterwards.
+//
+//   node --test scripts/fetch-job-log.test.mjs
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(new URL('./fetch-job-log.sh', import.meta.url));
+const directories = [];
+
+after(() => {
+  for (const directory of directories) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+/** Writes a job log the way the Actions API returns one. */
+const jobLog = (lines) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'job-log-'));
+  directories.push(directory);
+  const file = path.join(directory, 'job.log');
+  fs.writeFileSync(
+    file,
+    lines
+      .map((line, index) => {
+        const seconds = String(index % 60).padStart(2, '0');
+        return `2026-09-09T10:00:${seconds}.1234567Z ${line}\r\n`;
+      })
+      .join('')
+  );
+  return file;
+};
+
+const run = (sourceFile, env = {}) =>
+  execFileSync('bash', [script], {
+    env: { ...process.env, LOG_SOURCE_FILE: sourceFile, ...env },
+    encoding: 'utf8',
+  });
+
+const compile = [
+  '##[group]Run esphome/build-action@0000000',
+  '[32mINFO[0m Compiling app...',
+  '[12/345] Building CXX object src/foo.cpp.o',
+  'src/main.cpp:42:1: error: expected primary-expression',
+  '##[error]Process completed with exit code 1.',
+  '##[group]Run ./scripts/fetch-job-log.sh',
+  'Publishing the build failure',
+];
+
+test('strips timestamps, terminal escapes and runner markers', () => {
+  const printed = run(jobLog(compile));
+
+  assert.equal(
+    printed,
+    [
+      'INFO Compiling app...',
+      '[12/345] Building CXX object src/foo.cpp.o',
+      'src/main.cpp:42:1: error: expected primary-expression',
+      'ERROR: Process completed with exit code 1.',
+      'Publishing the build failure',
+      '',
+    ].join('\n')
+  );
+});
+
+test('ends the failure tail at the error, not at what the workflow did next', () => {
+  const printed = run(jobLog(compile), { LOG_END_AT_ERROR: 'true' });
+
+  assert.ok(
+    printed.includes('src/main.cpp:42:1: error: expected primary-expression'),
+    'the failure tail dropped the error that explains it'
+  );
+  assert.ok(
+    !printed.includes('Publishing the build failure'),
+    'the failure tail kept the workflow steps that ran after the failure'
+  );
+  assert.ok(printed.trimEnd().endsWith('exit code 1.'));
+});
+
+test('keeps only the end of a long log', () => {
+  const source = jobLog(
+    Array.from({ length: 500 }, (_, index) => `line ${index}`)
+  );
+
+  const lines = run(source, { LOG_TAIL_LINES: '5' }).trimEnd().split('\n');
+
+  assert.deepEqual(lines, [
+    'line 495',
+    'line 496',
+    'line 497',
+    'line 498',
+    'line 499',
+  ]);
+});
+
+test('caps what it prints in bytes as well as in lines', () => {
+  const source = jobLog([`a line that is ${'x'.repeat(200)} long`]);
+
+  const printed = run(source, { LOG_TAIL_LINES: '50', LOG_MAX_BYTES: '32' });
+
+  assert.equal(printed.length, 32);
+  assert.ok(printed.endsWith('long\n'));
+});
+
+test('fails rather than printing nothing when there is no log to read', () => {
+  assert.throws(
+    () => run(path.join(os.tmpdir(), 'no-such-job.log')),
+    /Command failed/,
+    'an unreadable log must exit non-zero, so the caller keeps the last one'
+  );
+});
+
+test('does not reach for the API without the environment it needs', () => {
+  assert.throws(
+    () =>
+      execFileSync('bash', [script], {
+        env: {
+          ...process.env,
+          LOG_SOURCE_FILE: '',
+          GITHUB_TOKEN: '',
+          GITHUB_REPOSITORY: 'tomquist/esphome-b2500',
+          GITHUB_RUN_ID: '1',
+        },
+        encoding: 'utf8',
+      }),
+    /Command failed/
+  );
+});

--- a/scripts/publish-build-log.sh
+++ b/scripts/publish-build-log.sh
@@ -27,6 +27,14 @@
 #     and compared, not just counted, and a read that fails the comparison is
 #     skipped. The page keeps a short log rather than a corrupt one.
 #
+# Two of these must never run at once. The workflow waits for the watcher to
+# exit before the final flush, but that wait has a deadline and the kill that
+# follows it reaches only the watcher, not a publisher it left mid-upload. Two
+# publishers sharing this state would both write the same segment key, and the
+# one that finished second would decide what it holds - dropping whatever the
+# other had put there. So the whole read-and-publish is taken under a lock, and
+# a publisher that cannot get it publishes nothing rather than racing.
+#
 # Usage: publish-build-log.sh
 #
 # Environment:
@@ -35,6 +43,7 @@
 #   LOG_FETCH_COMMAND     what prints the cleaned log, default fetch-job-log.sh
 #   LOG_STATE_PREFIX      where the published bytes and count are kept
 #   LOG_MAX_TOTAL_BYTES   stop publishing once this much has been published
+#   LOG_LOCK_WAIT_SECONDS how long to wait for another publisher to finish
 #   plus everything fetch-job-log.sh reads
 
 set -uo pipefail
@@ -48,17 +57,36 @@ COUNT_FILE="${STATE_PREFIX}.count"
 PUBLISHED_FILE="${STATE_PREFIX}.published"
 FULL_FILE="${STATE_PREFIX}.full"
 SEGMENT_FILE="${STATE_PREFIX}.segment"
+LOCK_FILE="${STATE_PREFIX}.lock"
+LOCK_WAIT_SECONDS="${LOG_LOCK_WAIT_SECONDS:-60}"
 
-count=$(cat "$COUNT_FILE" 2> /dev/null || echo 0)
-[[ "$count" =~ ^[0-9]+$ ]] || count=0
-offset=$(stat -c%s "$PUBLISHED_FILE" 2> /dev/null || echo 0)
+read_count() {
+  local value
+  value=$(cat "$COUNT_FILE" 2> /dev/null || echo 0)
+  [[ "$value" =~ ^[0-9]+$ ]] && echo "$value" || echo 0
+}
 
 # Whatever happens below, the caller needs the number of segments that exist,
-# so that a failure to publish a new one still names the ones that do.
+# so that a failure to publish a new one still names the ones that do. Read
+# back rather than remembered: another publisher may have moved it on.
 report() {
-  echo "$count"
+  read_count
   exit 0
 }
+
+# Held for the life of the script, released when it exits and the descriptor
+# closes. Where there is no flock to be had, carry on without one: this is best
+# effort, and the alternative is publishing nothing at all.
+if command -v flock > /dev/null 2>&1; then
+  exec {lock_fd}> "$LOCK_FILE" 2> /dev/null || lock_fd=''
+  if [[ -n "${lock_fd:-}" ]] && ! flock -w "$LOCK_WAIT_SECONDS" "$lock_fd"; then
+    echo "Another build output publisher is still running, skipping" >&2
+    report
+  fi
+fi
+
+count=$(read_count)
+offset=$(stat -c%s "$PUBLISHED_FILE" 2> /dev/null || echo 0)
 
 if [[ ! "${IDENTIFIER:-}" =~ ^[a-z0-9-]{1,64}$ || -z "${S3_BUCKET:-}" ]]; then
   echo "No usable build identifier or bucket, skipping log upload" >&2
@@ -98,8 +126,7 @@ if ! aws s3 cp "$SEGMENT_FILE" \
   report
 fi
 
-count=$((count + 1))
 cat "$SEGMENT_FILE" >> "$PUBLISHED_FILE"
-echo "$count" > "$COUNT_FILE"
-echo "Published build output segment $((count - 1)), $total bytes so far" >&2
+echo "$((count + 1))" > "$COUNT_FILE"
+echo "Published build output segment ${count}, $total bytes so far" >&2
 report

--- a/scripts/publish-build-log.sh
+++ b/scripts/publish-build-log.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Publishes the build output as append-only segments next to the status
+# document, and prints how many exist.
+#
+# S3 has no append: an object is replaced whole or not at all. Re-uploading one
+# growing object would mean sending the entire log every few seconds, and the
+# page re-reading it. So the log is published as a run of immutable segments -
+# `firmware/<identifier>.log.0`, `.log.1`, ... - each holding only the bytes
+# that appeared since the last one. Every byte is uploaded once and downloaded
+# once, which is the best a bucket with no server in front of it can do.
+#
+# The page learns how many exist from `log_segments` in the status document, so
+# a segment is always uploaded before the status that announces it. It never
+# has to guess whether a missing segment means "not yet" or "no more".
+#
+# Correctness rests on the cleaned log being a growing prefix of itself: the
+# job log the API returns only ever has lines appended, and cleaning is a
+# per-line transform. Two things can break that, and both are guarded here
+# rather than assumed away:
+#
+#   - a read that arrives cut mid-line, whose last line grows later. The fetch
+#     command is what can see that, and drops the unfinished line; the check
+#     below is what catches it having failed to.
+#   - a read whose earlier bytes are not the ones already published, which is
+#     what a moved start marker looks like. The bytes published so far are kept
+#     and compared, not just counted, and a read that fails the comparison is
+#     skipped. The page keeps a short log rather than a corrupt one.
+#
+# Usage: publish-build-log.sh
+#
+# Environment:
+#   IDENTIFIER            build identifier from the repository dispatch
+#   S3_BUCKET             target bucket
+#   LOG_FETCH_COMMAND     what prints the cleaned log, default fetch-job-log.sh
+#   LOG_STATE_PREFIX      where the published bytes and count are kept
+#   LOG_MAX_TOTAL_BYTES   stop publishing once this much has been published
+#   plus everything fetch-job-log.sh reads
+
+set -uo pipefail
+
+FETCH="${LOG_FETCH_COMMAND:-./scripts/fetch-job-log.sh}"
+STATE_PREFIX="${LOG_STATE_PREFIX:-build-log}"
+# A build that somehow prints without end must not publish without end either.
+MAX_TOTAL_BYTES="${LOG_MAX_TOTAL_BYTES:-4000000}"
+
+COUNT_FILE="${STATE_PREFIX}.count"
+PUBLISHED_FILE="${STATE_PREFIX}.published"
+FULL_FILE="${STATE_PREFIX}.full"
+SEGMENT_FILE="${STATE_PREFIX}.segment"
+
+count=$(cat "$COUNT_FILE" 2> /dev/null || echo 0)
+[[ "$count" =~ ^[0-9]+$ ]] || count=0
+offset=$(stat -c%s "$PUBLISHED_FILE" 2> /dev/null || echo 0)
+
+# Whatever happens below, the caller needs the number of segments that exist,
+# so that a failure to publish a new one still names the ones that do.
+report() {
+  echo "$count"
+  exit 0
+}
+
+if [[ ! "${IDENTIFIER:-}" =~ ^[a-z0-9-]{1,64}$ || -z "${S3_BUCKET:-}" ]]; then
+  echo "No usable build identifier or bucket, skipping log upload" >&2
+  report
+fi
+
+if [[ "$offset" -ge "$MAX_TOTAL_BYTES" ]]; then
+  echo "Published $offset bytes of build output already, not publishing more" >&2
+  report
+fi
+
+if ! "$FETCH" > "$FULL_FILE" 2> /dev/null || [[ ! -s "$FULL_FILE" ]]; then
+  report
+fi
+
+total=$(stat -c%s "$FULL_FILE" 2> /dev/null || echo 0)
+if [[ "$total" -le "$offset" ]]; then
+  report
+fi
+
+# The bytes already published have to still be there, and still be these ones.
+if [[ "$offset" -gt 0 ]] && ! cmp -s -n "$offset" "$PUBLISHED_FILE" "$FULL_FILE"; then
+  echo "Build output no longer starts with what was published, skipping" >&2
+  report
+fi
+
+# `tail -c +N` counts from one, so the byte after the offset is N = offset + 1.
+tail -c "+$((offset + 1))" "$FULL_FILE" > "$SEGMENT_FILE"
+[[ -s "$SEGMENT_FILE" ]] || report
+
+if ! aws s3 cp "$SEGMENT_FILE" \
+  "s3://${S3_BUCKET}/firmware/${IDENTIFIER}.log.${count}" \
+  --content-type 'text/plain; charset=utf-8' \
+  --cache-control 'public, max-age=31536000, immutable' > /dev/null; then
+  # The state is left alone so the same bytes go out again next time.
+  echo "Could not upload build output segment ${count}" >&2
+  report
+fi
+
+count=$((count + 1))
+cat "$SEGMENT_FILE" >> "$PUBLISHED_FILE"
+echo "$count" > "$COUNT_FILE"
+echo "Published build output segment $((count - 1)), $total bytes so far" >&2
+report

--- a/scripts/publish-build-log.sh
+++ b/scripts/publish-build-log.sh
@@ -114,7 +114,13 @@ if [[ "$offset" -gt 0 ]] && ! cmp -s -n "$offset" "$PUBLISHED_FILE" "$FULL_FILE"
 fi
 
 # `tail -c +N` counts from one, so the byte after the offset is N = offset + 1.
-tail -c "+$((offset + 1))" "$FULL_FILE" > "$SEGMENT_FILE"
+# Bounded by what is left of the budget rather than by the budget alone: the
+# check above only stops the publish *after* the cap is passed, so without this
+# the first segment could carry a runaway log whole. Cutting mid-line is fine
+# here - the page joins the segments back up, and the published bytes are still
+# a prefix of the log.
+tail -c "+$((offset + 1))" "$FULL_FILE" |
+  head -c "$((MAX_TOTAL_BYTES - offset))" > "$SEGMENT_FILE"
 [[ -s "$SEGMENT_FILE" ]] || report
 
 if ! aws s3 cp "$SEGMENT_FILE" \
@@ -128,5 +134,6 @@ fi
 
 cat "$SEGMENT_FILE" >> "$PUBLISHED_FILE"
 echo "$((count + 1))" > "$COUNT_FILE"
-echo "Published build output segment ${count}, $total bytes so far" >&2
+published=$(stat -c%s "$PUBLISHED_FILE" 2> /dev/null || echo "$total")
+echo "Published build output segment ${count}, $published bytes so far" >&2
 report

--- a/scripts/publish-build-log.test.mjs
+++ b/scripts/publish-build-log.test.mjs
@@ -1,0 +1,204 @@
+// S3 cannot append, so the build output is published as immutable segments and
+// the status document only says how many exist. These cover the property the
+// whole scheme rests on: every byte the compiler wrote is uploaded exactly
+// once, in order, and the count printed never names a segment that is not in
+// the bucket.
+//
+//   node --test scripts/publish-build-log.test.mjs
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(
+  new URL('./publish-build-log.sh', import.meta.url)
+);
+const directories = [];
+
+after(() => {
+  for (const directory of directories) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+const workspace = ({ uploadFails = false } = {}) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'publish-log-'));
+  directories.push(dir);
+  const uploads = path.join(dir, 'uploads');
+  fs.mkdirSync(uploads);
+
+  // Stands in for the AWS CLI: records what was uploaded under the key it was
+  // uploaded to. Invoked as `aws s3 cp <file> <key> --content-type ...`.
+  fs.mkdirSync(path.join(dir, 'bin'));
+  fs.writeFileSync(
+    path.join(dir, 'bin', 'aws'),
+    [
+      '#!/usr/bin/env bash',
+      `${uploadFails ? 'exit 1' : ''}`,
+      `cp "$3" "${uploads}/$(basename "$4")"`,
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+
+  // Stands in for fetch-job-log.sh: prints the log as it stands right now.
+  fs.writeFileSync(
+    path.join(dir, 'fetch-stub.sh'),
+    [
+      '#!/usr/bin/env bash',
+      `[[ -e "${path.join(dir, 'job.log')}" ]] || exit 1`,
+      `cat "${path.join(dir, 'job.log')}"`,
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+
+  return {
+    dir,
+    logFile: path.join(dir, 'job.log'),
+    write: (text) => fs.writeFileSync(path.join(dir, 'job.log'), text),
+    /** The segment bodies that reached the bucket, in order. */
+    uploaded: () =>
+      fs
+        .readdirSync(uploads)
+        .sort(
+          (a, b) => Number(a.split('.log.')[1]) - Number(b.split('.log.')[1])
+        )
+        .map((name) => [
+          name,
+          fs.readFileSync(path.join(uploads, name), 'utf8'),
+        ]),
+  };
+};
+
+/** Runs one publish and returns the segment count it printed. */
+const publish = (space, env = {}) =>
+  execFileSync('bash', [script], {
+    cwd: space.dir,
+    env: {
+      ...process.env,
+      PATH: `${path.join(space.dir, 'bin')}:${process.env.PATH}`,
+      IDENTIFIER: 'happy-tiny-otter-abc',
+      S3_BUCKET: 'a-bucket',
+      LOG_FETCH_COMMAND: path.join(space.dir, 'fetch-stub.sh'),
+      LOG_STATE_PREFIX: path.join(space.dir, 'state'),
+      ...env,
+    },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+
+test('uploads each byte of the build output exactly once, in order', () => {
+  const space = workspace();
+
+  space.write('Compiling app\n');
+  assert.equal(publish(space), '1');
+
+  space.write('Compiling app\nLinking b2500.elf\n');
+  assert.equal(publish(space), '2');
+
+  assert.deepEqual(space.uploaded(), [
+    ['happy-tiny-otter-abc.log.0', 'Compiling app\n'],
+    ['happy-tiny-otter-abc.log.1', 'Linking b2500.elf\n'],
+  ]);
+});
+
+test('publishes nothing when the build has not said anything new', () => {
+  const space = workspace();
+  space.write('Compiling app\n');
+
+  assert.equal(publish(space), '1');
+  assert.equal(publish(space), '1', 'the count must not move on its own');
+
+  assert.equal(space.uploaded().length, 1);
+});
+
+test('reports the segments that exist when there is no log to read', () => {
+  const space = workspace();
+
+  assert.equal(publish(space), '0');
+
+  space.write('Compiling app\n');
+  assert.equal(publish(space), '1');
+
+  // The API stops serving the log mid-build: what was published stays.
+  fs.rmSync(space.logFile);
+  assert.equal(publish(space), '1');
+  assert.equal(space.uploaded().length, 1);
+});
+
+test('skips a read that came back shorter than what was published', () => {
+  const space = workspace();
+  space.write('Compiling app\nLinking b2500.elf\n');
+  assert.equal(publish(space), '1');
+
+  // Offsets are only meaningful while the log grows. A short read is a bad
+  // read, not a signal to start over on top of what the page already has.
+  space.write('Compiling\n');
+  assert.equal(publish(space), '1');
+
+  assert.deepEqual(space.uploaded(), [
+    ['happy-tiny-otter-abc.log.0', 'Compiling app\nLinking b2500.elf\n'],
+  ]);
+});
+
+test('skips a read that is not the log it published before', () => {
+  const space = workspace();
+  space.write('Compiling app\nLinking b2500.elf\n');
+  assert.equal(publish(space), '1');
+
+  // What a moved start marker looks like: same shape, longer than what was
+  // published, different bytes. Publishing the difference would splice two
+  // unrelated logs together in the page.
+  space.write('Installing Python\nCompiling app\nLinking b2500.elf\n');
+  assert.equal(publish(space), '1');
+
+  assert.deepEqual(space.uploaded(), [
+    ['happy-tiny-otter-abc.log.0', 'Compiling app\nLinking b2500.elf\n'],
+  ]);
+});
+
+test('sends the same bytes again when the upload failed', () => {
+  const failing = workspace({ uploadFails: true });
+  failing.write('Compiling app\n');
+
+  assert.equal(publish(failing), '0', 'a failed upload must not be counted');
+  assert.equal(failing.uploaded().length, 0);
+
+  // Same state directory, working CLI: the bytes that never landed go out now.
+  fs.writeFileSync(
+    path.join(failing.dir, 'bin', 'aws'),
+    [
+      '#!/usr/bin/env bash',
+      `cp "$3" "${path.join(failing.dir, 'uploads')}/$(basename "$4")"`,
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+
+  assert.equal(publish(failing), '1');
+  assert.deepEqual(failing.uploaded(), [
+    ['happy-tiny-otter-abc.log.0', 'Compiling app\n'],
+  ]);
+});
+
+test('stops publishing a build that prints without end', () => {
+  const space = workspace();
+  space.write('x'.repeat(100));
+  assert.equal(publish(space, { LOG_MAX_TOTAL_BYTES: '50' }), '1');
+
+  space.write('x'.repeat(200));
+  assert.equal(publish(space, { LOG_MAX_TOTAL_BYTES: '50' }), '1');
+
+  assert.equal(space.uploaded().length, 1);
+});
+
+test('publishes nothing without a usable identifier or bucket', () => {
+  const space = workspace();
+  space.write('Compiling app\n');
+
+  assert.equal(publish(space, { IDENTIFIER: '../elsewhere' }), '0');
+  assert.equal(publish(space, { S3_BUCKET: '' }), '0');
+  assert.equal(space.uploaded().length, 0);
+});

--- a/scripts/publish-build-log.test.mjs
+++ b/scripts/publish-build-log.test.mjs
@@ -7,7 +7,7 @@
 //   node --test scripts/publish-build-log.test.mjs
 
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -192,6 +192,34 @@ test('stops publishing a build that prints without end', () => {
   assert.equal(publish(space, { LOG_MAX_TOTAL_BYTES: '50' }), '1');
 
   assert.equal(space.uploaded().length, 1);
+});
+
+test('publishes nothing while another publisher holds the lock', () => {
+  // The workflow's final flush can start while a publisher the watcher left
+  // behind is still uploading. Both would write the same segment key, and
+  // whichever finished last would decide what it holds.
+  const space = workspace();
+  space.write('Compiling app\n');
+
+  const holder = spawn(
+    'flock',
+    [path.join(space.dir, 'state.lock'), 'sleep', '5'],
+    { stdio: 'ignore' }
+  );
+  try {
+    // Give flock a moment to actually take it before racing it.
+    execFileSync('bash', ['-c', 'sleep 0.5']);
+    assert.equal(publish(space, { LOG_LOCK_WAIT_SECONDS: '1' }), '0');
+    assert.equal(space.uploaded().length, 0);
+  } finally {
+    holder.kill();
+  }
+
+  // Once it is free the same bytes go out, exactly once.
+  assert.equal(publish(space), '1');
+  assert.deepEqual(space.uploaded(), [
+    ['happy-tiny-otter-abc.log.0', 'Compiling app\n'],
+  ]);
 });
 
 test('publishes nothing without a usable identifier or bucket', () => {

--- a/scripts/publish-build-log.test.mjs
+++ b/scripts/publish-build-log.test.mjs
@@ -73,6 +73,38 @@ const workspace = ({ uploadFails = false } = {}) => {
   };
 };
 
+/** Whether something other than us currently holds `file`. */
+const isLocked = (file) => {
+  try {
+    execFileSync('flock', ['-n', file, 'true'], { stdio: 'ignore' });
+    return false;
+  } catch (error) {
+    return true;
+  }
+};
+
+const hasFlock = (() => {
+  try {
+    execFileSync('flock', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    return false;
+  }
+})();
+
+const waitFor = async (predicate, { timeoutMs = 15000 } = {}) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return false;
+};
+
+const exited = (child) => new Promise((resolve) => child.once('exit', resolve));
+
 /** Runs one publish and returns the segment count it printed. */
 const publish = (space, env = {}) =>
   execFileSync('bash', [script], {
@@ -199,33 +231,49 @@ test('stops publishing a build that prints without end', () => {
   ]);
 });
 
-test('publishes nothing while another publisher holds the lock', () => {
-  // The workflow's final flush can start while a publisher the watcher left
-  // behind is still uploading. Both would write the same segment key, and
-  // whichever finished last would decide what it holds.
-  const space = workspace();
-  space.write('Compiling app\n');
+// The script publishes without a lock where there is no flock to take one
+// with, so there is nothing to assert on such a machine.
+test(
+  'publishes nothing while another publisher holds the lock',
+  { skip: hasFlock ? false : 'flock is not installed' },
+  async () => {
+    // The workflow's final flush can start while a publisher the watcher left
+    // behind is still uploading. Both would write the same segment key, and
+    // whichever finished last would decide what it holds.
+    const space = workspace();
+    space.write('Compiling app\n');
+    const lock = path.join(space.dir, 'state.lock');
 
-  const holder = spawn(
-    'flock',
-    [path.join(space.dir, 'state.lock'), 'sleep', '5'],
-    { stdio: 'ignore' }
-  );
-  try {
-    // Give flock a moment to actually take it before racing it.
-    execFileSync('bash', ['-c', 'sleep 0.5']);
-    assert.equal(publish(space, { LOG_LOCK_WAIT_SECONDS: '1' }), '0');
-    assert.equal(space.uploaded().length, 0);
-  } finally {
-    holder.kill();
+    // Detached, so the group can be killed: flock passes the descriptor it
+    // holds to the command it runs, and killing flock alone would leave the
+    // child holding the lock.
+    const holder = spawn('flock', [lock, 'sleep', '30'], {
+      stdio: 'ignore',
+      detached: true,
+    });
+    try {
+      assert.ok(
+        await waitFor(() => isLocked(lock)),
+        'the holder never took the lock, so nothing was being contended'
+      );
+      assert.equal(publish(space, { LOG_LOCK_WAIT_SECONDS: '1' }), '0');
+      assert.equal(space.uploaded().length, 0);
+    } finally {
+      process.kill(-holder.pid, 'SIGTERM');
+      await exited(holder);
+    }
+    assert.ok(
+      await waitFor(() => !isLocked(lock)),
+      'the lock outlived the process holding it'
+    );
+
+    // Once it is free the same bytes go out, exactly once.
+    assert.equal(publish(space), '1');
+    assert.deepEqual(space.uploaded(), [
+      ['happy-tiny-otter-abc.log.0', 'Compiling app\n'],
+    ]);
   }
-
-  // Once it is free the same bytes go out, exactly once.
-  assert.equal(publish(space), '1');
-  assert.deepEqual(space.uploaded(), [
-    ['happy-tiny-otter-abc.log.0', 'Compiling app\n'],
-  ]);
-});
+);
 
 test('publishes nothing without a usable identifier or bucket', () => {
   const space = workspace();

--- a/scripts/publish-build-log.test.mjs
+++ b/scripts/publish-build-log.test.mjs
@@ -191,7 +191,12 @@ test('stops publishing a build that prints without end', () => {
   space.write('x'.repeat(200));
   assert.equal(publish(space, { LOG_MAX_TOTAL_BYTES: '50' }), '1');
 
-  assert.equal(space.uploaded().length, 1);
+  // The cap bounds the segment as well as the run of them: checking the offset
+  // alone only stops the publish after the budget is gone, so the first one
+  // would otherwise carry the whole runaway log.
+  assert.deepEqual(space.uploaded(), [
+    ['happy-tiny-otter-abc.log.0', 'x'.repeat(50)],
+  ]);
 });
 
 test('publishes nothing while another publisher holds the lock', () => {

--- a/scripts/publish-build-status.sh
+++ b/scripts/publish-build-status.sh
@@ -13,8 +13,7 @@
 #   STEP             what the build is doing: preparing, compiling, packaging
 #   PROGRESS_DONE    compile units finished so far (with PROGRESS_TOTAL)
 #   PROGRESS_TOTAL   compile units the build expects in total
-#   BUILD_LOG_FILE   file holding the tail of the build output to publish
-#   BUILD_LOG_MAX_BYTES  how much of that file to publish, from the end
+#   LOG_SEGMENTS     how many build output segments exist (publish-build-log.sh)
 #   FIRMWARE_URL     download URL of the firmware ZIP (success only)
 #   FIRMWARE_NAME    name of the firmware directory inside the ZIP
 #   ESPHOME_VERSION  ESPHome version the firmware was built with
@@ -24,14 +23,12 @@ set -euo pipefail
 STATUS="${1:?usage: publish-build-status.sh <status> [message]}"
 MESSAGE="${2:-}"
 
-# The tail of the build output, so the page can show what the compiler is doing
-# and what it said when it stopped. Capped here as well as where it is
-# collected: this document is polled every few seconds for the length of a
-# build, and it is the collector that would have to be wrong for it to matter.
-BUILD_LOG=''
-if [[ -n "${BUILD_LOG_FILE:-}" && -s "${BUILD_LOG_FILE}" ]]; then
-  BUILD_LOG=$(tail -c "${BUILD_LOG_MAX_BYTES:-24000}" "$BUILD_LOG_FILE")
-fi
+# The build output itself is published as its own objects; this document only
+# says how many of them there are. It is fetched every few seconds for the
+# length of a build, so it stays small and stops growing with the compiler's
+# appetite for talking.
+SEGMENTS="${LOG_SEGMENTS:-0}"
+[[ "$SEGMENTS" =~ ^[0-9]+$ ]] || SEGMENTS=0
 
 if [[ ! "${IDENTIFIER:-}" =~ ^[a-z0-9-]{1,64}$ ]]; then
   echo "No usable build identifier, skipping status upload"
@@ -47,24 +44,23 @@ jq -n \
   --arg firmware_url "${FIRMWARE_URL:-}" \
   --arg firmware_name "${FIRMWARE_NAME:-}" \
   --arg esphome_version "${ESPHOME_VERSION:-}" \
-  --arg log "$BUILD_LOG" \
   --argjson done "${PROGRESS_DONE:-0}" \
   --argjson total "${PROGRESS_TOTAL:-0}" \
+  --argjson segments "$SEGMENTS" \
   --arg updated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   '{status: $status, identifier: $identifier, updated_at: $updated_at}
-    + ({run_url: $run_url, message: $message, step: $step, log: $log,
+    + ({run_url: $run_url, message: $message, step: $step,
         firmware_url: $firmware_url, firmware_name: $firmware_name,
         esphome_version: $esphome_version}
        | with_entries(select(.value != "")))
     + (if $done > 0 or $total > 0
        then {progress: ({completed: $done}
                         + (if $total > 0 then {total: $total} else {} end))}
-       else {} end)' \
+       else {} end)
+    + (if $segments > 0 then {log_segments: $segments} else {} end)' \
   > build-status.json
 
-# Without the log: it is republished every few seconds and would bury the rest
-# of this job's output in copies of the compiler's.
-jq 'del(.log)' build-status.json
+cat build-status.json
 
 aws s3 cp build-status.json "s3://${S3_BUCKET}/firmware/${IDENTIFIER}.status.json" \
   --content-type application/json \

--- a/scripts/publish-build-status.sh
+++ b/scripts/publish-build-status.sh
@@ -13,6 +13,8 @@
 #   STEP             what the build is doing: preparing, compiling, packaging
 #   PROGRESS_DONE    compile units finished so far (with PROGRESS_TOTAL)
 #   PROGRESS_TOTAL   compile units the build expects in total
+#   BUILD_LOG_FILE   file holding the tail of the build output to publish
+#   BUILD_LOG_MAX_BYTES  how much of that file to publish, from the end
 #   FIRMWARE_URL     download URL of the firmware ZIP (success only)
 #   FIRMWARE_NAME    name of the firmware directory inside the ZIP
 #   ESPHOME_VERSION  ESPHome version the firmware was built with
@@ -21,6 +23,15 @@ set -euo pipefail
 
 STATUS="${1:?usage: publish-build-status.sh <status> [message]}"
 MESSAGE="${2:-}"
+
+# The tail of the build output, so the page can show what the compiler is doing
+# and what it said when it stopped. Capped here as well as where it is
+# collected: this document is polled every few seconds for the length of a
+# build, and it is the collector that would have to be wrong for it to matter.
+BUILD_LOG=''
+if [[ -n "${BUILD_LOG_FILE:-}" && -s "${BUILD_LOG_FILE}" ]]; then
+  BUILD_LOG=$(tail -c "${BUILD_LOG_MAX_BYTES:-24000}" "$BUILD_LOG_FILE")
+fi
 
 if [[ ! "${IDENTIFIER:-}" =~ ^[a-z0-9-]{1,64}$ ]]; then
   echo "No usable build identifier, skipping status upload"
@@ -36,11 +47,12 @@ jq -n \
   --arg firmware_url "${FIRMWARE_URL:-}" \
   --arg firmware_name "${FIRMWARE_NAME:-}" \
   --arg esphome_version "${ESPHOME_VERSION:-}" \
+  --arg log "$BUILD_LOG" \
   --argjson done "${PROGRESS_DONE:-0}" \
   --argjson total "${PROGRESS_TOTAL:-0}" \
   --arg updated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   '{status: $status, identifier: $identifier, updated_at: $updated_at}
-    + ({run_url: $run_url, message: $message, step: $step,
+    + ({run_url: $run_url, message: $message, step: $step, log: $log,
         firmware_url: $firmware_url, firmware_name: $firmware_name,
         esphome_version: $esphome_version}
        | with_entries(select(.value != "")))
@@ -50,7 +62,9 @@ jq -n \
        else {} end)' \
   > build-status.json
 
-cat build-status.json
+# Without the log: it is republished every few seconds and would bury the rest
+# of this job's output in copies of the compiler's.
+jq 'del(.log)' build-status.json
 
 aws s3 cp build-status.json "s3://${S3_BUCKET}/firmware/${IDENTIFIER}.status.json" \
   --content-type application/json \

--- a/scripts/watch-build-progress.sh
+++ b/scripts/watch-build-progress.sh
@@ -6,8 +6,13 @@
 #
 # ESP-IDF builds with ninja, which writes one object file per compile unit into
 # the build tree and declares every one of them in the generated build.ninja.
-# Counting both gives a progress fraction without having to parse the build log,
-# which belongs to the action running the compile rather than to us.
+# Counting both gives a progress fraction that does not depend on being able to
+# read the compiler's output.
+#
+# It reads that output too, when the API lets it: fetch-job-log.sh pulls this
+# job's own log back, and the tail of it goes into the same status document, so
+# the page can show the build talking rather than only a bar moving. That part
+# is best effort - a build whose log cannot be read still reports progress.
 #
 # Runs in the background alongside the build step. It stops when the stop file
 # appears, which it only checks between polls: an upload in flight always
@@ -17,10 +22,19 @@
 
 set -uo pipefail
 
-INTERVAL_SECONDS="${PROGRESS_INTERVAL_SECONDS:-15}"
+INTERVAL_SECONDS="${PROGRESS_INTERVAL_SECONDS:-5}"
 STOP_FILE="${PROGRESS_STOP_FILE:-progress-watcher.stop}"
 BUILD_ROOT="${PROGRESS_BUILD_ROOT:-.esphome/build}"
 PUBLISH="${PROGRESS_PUBLISH_COMMAND:-./scripts/publish-build-status.sh}"
+LOG_COMMAND="${PROGRESS_LOG_COMMAND:-./scripts/fetch-job-log.sh}"
+# Slower than the poll: reading the log costs an API request against a limit
+# every build in the repository shares, while counting files costs nothing.
+# Zero turns log reporting off.
+LOG_INTERVAL_SECONDS="${PROGRESS_LOG_INTERVAL_SECONDS:-10}"
+LOG_FILE="${PROGRESS_LOG_FILE:-build-log.tail}"
+# The ninja graph is written once and then only grows by the second graph, so
+# re-reading it every poll would spend most of the interval grepping megabytes.
+TOTAL_REFRESH_SECONDS="${PROGRESS_TOTAL_REFRESH_SECONDS:-60}"
 
 count_objects() {
   find "$BUILD_ROOT" -type f \( -name '*.obj' -o -name '*.o' \) 2>/dev/null |
@@ -35,15 +49,69 @@ count_expected_objects() {
     awk '{ sum += $1 } END { print sum + 0 }'
 }
 
+now() { date +%s; }
+
+expected=0
+expected_read_at=0
+
+# Keeps the cached total until it is worth paying for again: while it is still
+# unknown, once the refresh interval has passed, and whenever the build has
+# overtaken it - which is what a graph read before the second one existed looks
+# like.
+refresh_expected() {
+  local moment
+  moment=$(now)
+  if [[ "$expected" -gt 0 &&
+        "$expected" -ge "$completed" &&
+        $((moment - expected_read_at)) -lt "$TOTAL_REFRESH_SECONDS" ]]; then
+    return
+  fi
+  expected=$(count_expected_objects)
+  expected_read_at=$moment
+}
+
+log_read_at=0
+
+refresh_log() {
+  [[ "$LOG_INTERVAL_SECONDS" -gt 0 ]] || return
+  local moment
+  moment=$(now)
+  if [[ $((moment - log_read_at)) -lt "$LOG_INTERVAL_SECONDS" ]]; then
+    return
+  fi
+  log_read_at=$moment
+  local pending="${LOG_FILE}.pending"
+  if "$LOG_COMMAND" > "$pending" 2>/dev/null && [[ -s "$pending" ]]; then
+    mv -f "$pending" "$LOG_FILE"
+  else
+    rm -f "$pending"
+  fi
+}
+
+log_fingerprint() {
+  [[ -s "$LOG_FILE" ]] || return 0
+  cksum < "$LOG_FILE" 2>/dev/null
+}
+
 last_completed=''
+last_log=''
 while [[ ! -e "$STOP_FILE" ]]; do
   completed=$(count_objects)
-  if [[ "$completed" -gt 0 && "$completed" != "$last_completed" ]]; then
+  refresh_expected
+  refresh_log
+  log=$(log_fingerprint)
+  # Republish for either half: early on there are no object files yet but the
+  # log already has the configure step to show, and late in a link step the
+  # count stands still while the output keeps moving.
+  if [[ "$completed" != "$last_completed" || "$log" != "$last_log" ]] &&
+     [[ "$completed" -gt 0 || -s "$LOG_FILE" ]]; then
     STEP=compiling \
       PROGRESS_DONE="$completed" \
-      PROGRESS_TOTAL="$(count_expected_objects)" \
+      PROGRESS_TOTAL="$expected" \
+      BUILD_LOG_FILE="$LOG_FILE" \
       "$PUBLISH" building "Compiling the firmware" > /dev/null || true
     last_completed="$completed"
+    last_log="$log"
   fi
   # Sleep in short ticks so that stopping does not have to wait out a full
   # interval, and so that it is noticed here rather than during a publish.

--- a/scripts/watch-build-progress.sh
+++ b/scripts/watch-build-progress.sh
@@ -9,10 +9,10 @@
 # Counting both gives a progress fraction that does not depend on being able to
 # read the compiler's output.
 #
-# It reads that output too, when the API lets it: fetch-job-log.sh pulls this
-# job's own log back, and the tail of it goes into the same status document, so
-# the page can show the build talking rather than only a bar moving. That part
-# is best effort - a build whose log cannot be read still reports progress.
+# It publishes that output too, when the API lets it: publish-build-log.sh
+# uploads whatever the compiler has said since the last time as its own object,
+# and the status document carries only how many of those exist. That part is
+# best effort - a build whose log cannot be read still reports progress.
 #
 # Runs in the background alongside the build step. It stops when the stop file
 # appears, which it only checks between polls: an upload in flight always
@@ -26,12 +26,12 @@ INTERVAL_SECONDS="${PROGRESS_INTERVAL_SECONDS:-5}"
 STOP_FILE="${PROGRESS_STOP_FILE:-progress-watcher.stop}"
 BUILD_ROOT="${PROGRESS_BUILD_ROOT:-.esphome/build}"
 PUBLISH="${PROGRESS_PUBLISH_COMMAND:-./scripts/publish-build-status.sh}"
-LOG_COMMAND="${PROGRESS_LOG_COMMAND:-./scripts/fetch-job-log.sh}"
+LOG_COMMAND="${PROGRESS_LOG_COMMAND:-./scripts/publish-build-log.sh}"
 # Slower than the poll: reading the log costs an API request against a limit
-# every build in the repository shares, while counting files costs nothing.
-# Zero turns log reporting off.
+# every build in the repository shares, while counting files costs nothing. At
+# ten seconds a busy hour of builds stays well inside it. Zero turns log
+# reporting off.
 LOG_INTERVAL_SECONDS="${PROGRESS_LOG_INTERVAL_SECONDS:-10}"
-LOG_FILE="${PROGRESS_LOG_FILE:-build-log.tail}"
 # The ninja graph is written once and then only grows by the second graph, so
 # re-reading it every poll would spend most of the interval grepping megabytes.
 TOTAL_REFRESH_SECONDS="${PROGRESS_TOTAL_REFRESH_SECONDS:-60}"
@@ -71,47 +71,43 @@ refresh_expected() {
 }
 
 log_read_at=0
+segments=0
 
+# Uploads whatever the build has said since the last segment and reports how
+# many segments now exist. Publishing the log is what advances that count, so
+# the object is always in the bucket before the status document names it.
 refresh_log() {
   [[ "$LOG_INTERVAL_SECONDS" -gt 0 ]] || return
-  local moment
+  local moment published
   moment=$(now)
   if [[ $((moment - log_read_at)) -lt "$LOG_INTERVAL_SECONDS" ]]; then
     return
   fi
   log_read_at=$moment
-  local pending="${LOG_FILE}.pending"
-  if "$LOG_COMMAND" > "$pending" 2>/dev/null && [[ -s "$pending" ]]; then
-    mv -f "$pending" "$LOG_FILE"
-  else
-    rm -f "$pending"
+  published=$("$LOG_COMMAND" 2>/dev/null)
+  if [[ "$published" =~ ^[0-9]+$ ]]; then
+    segments=$published
   fi
 }
 
-log_fingerprint() {
-  [[ -s "$LOG_FILE" ]] || return 0
-  cksum < "$LOG_FILE" 2>/dev/null
-}
-
 last_completed=''
-last_log=''
+last_segments=''
 while [[ ! -e "$STOP_FILE" ]]; do
   completed=$(count_objects)
   refresh_expected
   refresh_log
-  log=$(log_fingerprint)
   # Republish for either half: early on there are no object files yet but the
   # log already has the configure step to show, and late in a link step the
   # count stands still while the output keeps moving.
-  if [[ "$completed" != "$last_completed" || "$log" != "$last_log" ]] &&
-     [[ "$completed" -gt 0 || -s "$LOG_FILE" ]]; then
+  if [[ "$completed" != "$last_completed" || "$segments" != "$last_segments" ]] &&
+     [[ "$completed" -gt 0 || "$segments" -gt 0 ]]; then
     STEP=compiling \
       PROGRESS_DONE="$completed" \
       PROGRESS_TOTAL="$expected" \
-      BUILD_LOG_FILE="$LOG_FILE" \
+      LOG_SEGMENTS="$segments" \
       "$PUBLISH" building "Compiling the firmware" > /dev/null || true
     last_completed="$completed"
-    last_log="$log"
+    last_segments="$segments"
   fi
   # Sleep in short ticks so that stopping does not have to wait out a full
   # interval, and so that it is noticed here rather than during a publish.

--- a/scripts/watch-build-progress.test.mjs
+++ b/scripts/watch-build-progress.test.mjs
@@ -53,24 +53,22 @@ const workspace = ({ objects, expected, publishSeconds = 0 }) => {
     [
       '#!/usr/bin/env bash',
       `echo "start $PROGRESS_DONE/$PROGRESS_TOTAL" >> "${path.join(dir, 'published.log')}"`,
-      'if [[ -s "${BUILD_LOG_FILE:-}" ]]; then',
-      `  cat "$BUILD_LOG_FILE" >> "${path.join(dir, 'published-output.log')}"`,
-      'fi',
+      `echo "segments ${'$'}{LOG_SEGMENTS:-none}" >> "${path.join(dir, 'published-segments.log')}"`,
       `sleep ${publishSeconds}`,
       `echo "end $PROGRESS_DONE/$PROGRESS_TOTAL" >> "${path.join(dir, 'published.log')}"`,
     ].join('\n'),
     { mode: 0o755 }
   );
 
-  // Stands in for fetch-job-log.sh: prints whatever the test last put in the
-  // job log, and fails while there is nothing to read - the way an API that
-  // has not published the log yet does.
+  // Stands in for publish-build-log.sh: prints how many output segments it has
+  // published, and fails while there is nothing to read - the way a build whose
+  // log the API will not serve behaves.
   fs.writeFileSync(
     path.join(dir, 'log-stub.sh'),
     [
       '#!/usr/bin/env bash',
-      `[[ -s "${path.join(dir, 'job.log')}" ]] || exit 1`,
-      `cat "${path.join(dir, 'job.log')}"`,
+      `[[ -s "${path.join(dir, 'segments')}" ]] || exit 1`,
+      `cat "${path.join(dir, 'segments')}"`,
     ].join('\n'),
     { mode: 0o755 }
   );
@@ -83,9 +81,9 @@ const workspace = ({ objects, expected, publishSeconds = 0 }) => {
   return {
     dir,
     stopFile: path.join(dir, 'stop'),
-    jobLog: path.join(dir, 'job.log'),
+    segmentsFile: path.join(dir, 'segments'),
     published: () => lines('published.log'),
-    publishedOutput: () => lines('published-output.log'),
+    publishedSegments: () => lines('published-segments.log'),
   };
 };
 
@@ -163,27 +161,26 @@ test('finishes an upload that overlaps being stopped, and publishes nothing afte
   );
 });
 
-test('reports the build output, and republishes it when only it changed', async () => {
+test('republishes when a new build output segment appears', async () => {
   const space = workspace({ objects: 2, expected: 4 });
-  fs.writeFileSync(space.jobLog, 'Compiling app\n');
+  fs.writeFileSync(space.segmentsFile, '1\n');
   const child = start(space, { logIntervalSeconds: 1 });
 
-  assert.ok(
-    await waitFor(() => space.publishedOutput().includes('Compiling app')),
-    'the watcher published no build output'
+  const announced = await waitFor(() =>
+    space.publishedSegments().includes('segments 1')
   );
-
   // The count stands still through a link step, which is exactly when the
   // output is the only thing left to show.
-  fs.writeFileSync(space.jobLog, 'Linking b2500.elf\n');
-
+  fs.writeFileSync(space.segmentsFile, '2\n');
   const republished = await waitFor(() =>
-    space.publishedOutput().includes('Linking b2500.elf')
+    space.publishedSegments().includes('segments 2')
   );
+
   fs.writeFileSync(space.stopFile, '');
   await exited(child);
 
-  assert.ok(republished, 'the watcher sat on build output that had changed');
+  assert.ok(announced, 'the watcher never published a segment count');
+  assert.ok(republished, 'the watcher sat on a segment it had just published');
   assert.deepEqual(
     space.published().filter((line) => line.startsWith('start')),
     ['start 2/4', 'start 2/4'],
@@ -191,18 +188,20 @@ test('reports the build output, and republishes it when only it changed', async 
   );
 });
 
-test('keeps reporting progress when the build output cannot be read', async () => {
-  // No job log at all, so the stub fails the way the API does when the log is
-  // not there yet or the token cannot read it.
+test('keeps reporting progress when the build output cannot be published', async () => {
+  // No segment count at all, so the stub fails the way publish-build-log.sh
+  // does when the API will not serve this job's log.
   const space = workspace({ objects: 3, expected: 6 });
   const child = start(space, { logIntervalSeconds: 1 });
 
-  assert.ok(
-    await waitFor(() => space.published().includes('end 3/6')),
-    'a build whose log cannot be read stopped reporting progress'
-  );
+  const reported = await waitFor(() => space.published().includes('end 3/6'));
+
   fs.writeFileSync(space.stopFile, '');
   await exited(child);
 
-  assert.deepEqual(space.publishedOutput(), []);
+  assert.ok(
+    reported,
+    'a build whose log cannot be published stopped reporting progress'
+  );
+  assert.deepEqual(space.publishedSegments(), ['segments 0']);
 });

--- a/scripts/watch-build-progress.test.mjs
+++ b/scripts/watch-build-progress.test.mjs
@@ -46,32 +46,52 @@ const workspace = ({ objects, expected, publishSeconds = 0 }) => {
   }
 
   // Records when each publish starts and finishes, so a publish that overlaps
-  // the stop can be told apart from one that started after it.
+  // the stop can be told apart from one that started after it, and what build
+  // output each one carried.
   fs.writeFileSync(
     path.join(dir, 'publish-stub.sh'),
     [
       '#!/usr/bin/env bash',
       `echo "start $PROGRESS_DONE/$PROGRESS_TOTAL" >> "${path.join(dir, 'published.log')}"`,
+      'if [[ -s "${BUILD_LOG_FILE:-}" ]]; then',
+      `  cat "$BUILD_LOG_FILE" >> "${path.join(dir, 'published-output.log')}"`,
+      'fi',
       `sleep ${publishSeconds}`,
       `echo "end $PROGRESS_DONE/$PROGRESS_TOTAL" >> "${path.join(dir, 'published.log')}"`,
     ].join('\n'),
     { mode: 0o755 }
   );
 
+  // Stands in for fetch-job-log.sh: prints whatever the test last put in the
+  // job log, and fails while there is nothing to read - the way an API that
+  // has not published the log yet does.
+  fs.writeFileSync(
+    path.join(dir, 'log-stub.sh'),
+    [
+      '#!/usr/bin/env bash',
+      `[[ -s "${path.join(dir, 'job.log')}" ]] || exit 1`,
+      `cat "${path.join(dir, 'job.log')}"`,
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+
+  const lines = (name) =>
+    fs.existsSync(path.join(dir, name))
+      ? fs.readFileSync(path.join(dir, name), 'utf8').trim().split('\n')
+      : [];
+
   return {
     dir,
     stopFile: path.join(dir, 'stop'),
-    published: () =>
-      fs.existsSync(path.join(dir, 'published.log'))
-        ? fs
-            .readFileSync(path.join(dir, 'published.log'), 'utf8')
-            .trim()
-            .split('\n')
-        : [],
+    jobLog: path.join(dir, 'job.log'),
+    published: () => lines('published.log'),
+    publishedOutput: () => lines('published-output.log'),
   };
 };
 
-const start = (space, { intervalSeconds = 1 } = {}) =>
+// Reporting the build output is off unless a test asks for it: it is best
+// effort in the workflow too, and the counting has to hold up without it.
+const start = (space, { intervalSeconds = 1, logIntervalSeconds = 0 } = {}) =>
   spawn('bash', [watcher], {
     cwd: space.dir,
     env: {
@@ -79,6 +99,8 @@ const start = (space, { intervalSeconds = 1 } = {}) =>
       PROGRESS_INTERVAL_SECONDS: String(intervalSeconds),
       PROGRESS_STOP_FILE: space.stopFile,
       PROGRESS_PUBLISH_COMMAND: path.join(space.dir, 'publish-stub.sh'),
+      PROGRESS_LOG_COMMAND: path.join(space.dir, 'log-stub.sh'),
+      PROGRESS_LOG_INTERVAL_SECONDS: String(logIntervalSeconds),
     },
     stdio: 'ignore',
   });
@@ -139,4 +161,48 @@ test('finishes an upload that overlaps being stopped, and publishes nothing afte
     ['start 2/4', 'end 2/4'],
     'the in-flight upload must finish, and nothing may be published after the stop'
   );
+});
+
+test('reports the build output, and republishes it when only it changed', async () => {
+  const space = workspace({ objects: 2, expected: 4 });
+  fs.writeFileSync(space.jobLog, 'Compiling app\n');
+  const child = start(space, { logIntervalSeconds: 1 });
+
+  assert.ok(
+    await waitFor(() => space.publishedOutput().includes('Compiling app')),
+    'the watcher published no build output'
+  );
+
+  // The count stands still through a link step, which is exactly when the
+  // output is the only thing left to show.
+  fs.writeFileSync(space.jobLog, 'Linking b2500.elf\n');
+
+  const republished = await waitFor(() =>
+    space.publishedOutput().includes('Linking b2500.elf')
+  );
+  fs.writeFileSync(space.stopFile, '');
+  await exited(child);
+
+  assert.ok(republished, 'the watcher sat on build output that had changed');
+  assert.deepEqual(
+    space.published().filter((line) => line.startsWith('start')),
+    ['start 2/4', 'start 2/4'],
+    'both publishes must carry the same unchanged counts'
+  );
+});
+
+test('keeps reporting progress when the build output cannot be read', async () => {
+  // No job log at all, so the stub fails the way the API does when the log is
+  // not there yet or the token cannot read it.
+  const space = workspace({ objects: 3, expected: 6 });
+  const child = start(space, { logIntervalSeconds: 1 });
+
+  assert.ok(
+    await waitFor(() => space.published().includes('end 3/6')),
+    'a build whose log cannot be read stopped reporting progress'
+  );
+  fs.writeFileSync(space.stopFile, '');
+  await exited(child);
+
+  assert.deepEqual(space.publishedOutput(), []);
 });

--- a/src/components/BuildProgressDialog.tsx
+++ b/src/components/BuildProgressDialog.tsx
@@ -32,6 +32,7 @@ import {
   BuildStatus,
   BuildStep,
   BuildTimeoutError,
+  appendLogText,
   buildListUrl,
   fetchLogSegment,
   firmwareDownloadUrl,
@@ -229,8 +230,12 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
               return; // Announced but not readable yet.
             }
             cursor += 1;
-            if (segment.length > 0) {
-              setBuildLog((previous) => (previous ?? '') + segment);
+            // Bound to a const: narrowing `segment` does not reach inside the
+            // updater, and concatenating it while it is still `string | null`
+            // would put the word "null" in the log rather than fail.
+            const text = segment;
+            if (text.length > 0) {
+              setBuildLog((previous) => appendLogText(previous ?? '', text));
             }
           }
         });

--- a/src/components/BuildProgressDialog.tsx
+++ b/src/components/BuildProgressDialog.tsx
@@ -101,7 +101,7 @@ const compiledFiles = (status: BuildStatus | null): string | null => {
  * every few seconds for the length of the compile.
  */
 const BuildLog: React.FC<{ log: string }> = ({ log }) => {
-  const box = useRef<HTMLElement | null>(null);
+  const box = useRef<HTMLPreElement>(null);
   const isPinned = useRef(true);
 
   useEffect(() => {

--- a/src/components/BuildProgressDialog.tsx
+++ b/src/components/BuildProgressDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Accordion,
   AccordionDetails,
@@ -92,6 +92,52 @@ const compiledFiles = (status: BuildStatus | null): string | null => {
     : `${progress.completed} files`;
 };
 
+/**
+ * The tail of the build output, pinned to its last line.
+ *
+ * Anchored only while it is already at the bottom, so a user who scrolled up to
+ * read an error is not yanked back down by the next update - which arrives
+ * every few seconds for the length of the compile.
+ */
+const BuildLog: React.FC<{ log: string }> = ({ log }) => {
+  const box = useRef<HTMLElement | null>(null);
+  const isPinned = useRef(true);
+
+  useEffect(() => {
+    const node = box.current;
+    if (node && isPinned.current) {
+      node.scrollTop = node.scrollHeight;
+    }
+  }, [log]);
+
+  return (
+    <Box
+      component="pre"
+      ref={box}
+      onScroll={(event: React.UIEvent<HTMLElement>) => {
+        const node = event.currentTarget;
+        isPinned.current =
+          node.scrollHeight - node.scrollTop - node.clientHeight < 24;
+      }}
+      sx={{
+        m: 0,
+        p: 1,
+        maxHeight: 220,
+        overflow: 'auto',
+        bgcolor: 'action.hover',
+        borderRadius: 1,
+        fontFamily: 'monospace',
+        fontSize: '0.72rem',
+        lineHeight: 1.5,
+        whiteSpace: 'pre-wrap',
+        overflowWrap: 'anywhere',
+      }}
+    >
+      {log}
+    </Box>
+  );
+};
+
 const formatDuration = (seconds: number) => {
   const minutes = Math.floor(seconds / 60);
   const remainder = Math.floor(seconds % 60);
@@ -142,6 +188,10 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [attempt, setAttempt] = useState(0);
   const [isStatusUnreachable, setIsStatusUnreachable] = useState(false);
+  // Kept out of `status` so it survives the polls that carry no log - the
+  // workflow only republishes the tail when it has changed, and a build that
+  // loses access to its own log mid-compile should keep what it already showed.
+  const [buildLog, setBuildLog] = useState<string | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -154,6 +204,7 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
       setArchive(null);
       setDidBuildFail(false);
       setIsStatusUnreachable(false);
+      setBuildLog(null);
       try {
         const finalStatus = await pollBuildStatus({
           identifier,
@@ -161,6 +212,9 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
           onStatus: (update) => {
             setStatus(update);
             setIsStatusUnreachable(false);
+            if (update.log) {
+              setBuildLog(update.log);
+            }
           },
           // A handful of failures in a row usually means the browser blocked
           // the request, e.g. because the bucket is missing a CORS rule.
@@ -326,6 +380,14 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
               {didBuildFail ? 'Build failed' : 'Could not prepare the firmware'}
             </AlertTitle>
             {error}
+            {buildLog && (
+              <Box sx={{ mt: 1 }}>
+                <Typography variant="caption" color="text.secondary">
+                  Build output
+                </Typography>
+                <BuildLog log={buildLog} />
+              </Box>
+            )}
             <Box sx={{ mt: 1 }}>
               <Link href={runLink} target="_blank" rel="noopener">
                 View build log
@@ -373,6 +435,16 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
                     View build log
                   </Link>
                 </Typography>
+                {buildLog && (
+                  <Accordion sx={{ mt: 1 }} disableGutters defaultExpanded>
+                    <AccordionSummary expandIcon={<ExpandMore />}>
+                      <Typography variant="body2">Build output</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ p: 1, pt: 0 }}>
+                      <BuildLog log={buildLog} />
+                    </AccordionDetails>
+                  </Accordion>
+                )}
               </StepContent>
             </Step>
             <Step>

--- a/src/components/BuildProgressDialog.tsx
+++ b/src/components/BuildProgressDialog.tsx
@@ -33,6 +33,7 @@ import {
   BuildStep,
   BuildTimeoutError,
   buildListUrl,
+  fetchLogSegment,
   firmwareDownloadUrl,
   pollBuildStatus,
 } from '../firmware/buildStatus';
@@ -188,9 +189,8 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [attempt, setAttempt] = useState(0);
   const [isStatusUnreachable, setIsStatusUnreachable] = useState(false);
-  // Kept out of `status` so it survives the polls that carry no log - the
-  // workflow only republishes the tail when it has changed, and a build that
-  // loses access to its own log mid-compile should keep what it already showed.
+  // Accumulated from the log segments, so it only ever grows. A build that
+  // loses access to its own log mid-compile keeps what it already showed.
   const [buildLog, setBuildLog] = useState<string | null>(null);
 
   useEffect(() => {
@@ -205,6 +205,38 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
       setDidBuildFail(false);
       setIsStatusUnreachable(false);
       setBuildLog(null);
+
+      // Segments are downloaded once each, in order, as the status document
+      // announces them. Chained rather than guarded by a flag so that the last
+      // call can be awaited: a failed build's error is usually in the segment
+      // the workflow published just before it said the build had failed.
+      let cursor = 0;
+      let pumping: Promise<void> = Promise.resolve();
+      const pumpLog = (available: number) => {
+        pumping = pumping.then(async () => {
+          while (cursor < available && !controller.signal.aborted) {
+            let segment: string | null = null;
+            try {
+              segment = await fetchLogSegment(
+                identifier,
+                cursor,
+                controller.signal
+              );
+            } catch (caught) {
+              return; // Transient, or aborted. The next status brings us back.
+            }
+            if (segment === null) {
+              return; // Announced but not readable yet.
+            }
+            cursor += 1;
+            if (segment.length > 0) {
+              setBuildLog((previous) => (previous ?? '') + segment);
+            }
+          }
+        });
+        return pumping;
+      };
+
       try {
         const finalStatus = await pollBuildStatus({
           identifier,
@@ -212,8 +244,8 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
           onStatus: (update) => {
             setStatus(update);
             setIsStatusUnreachable(false);
-            if (update.log) {
-              setBuildLog(update.log);
+            if (update.logSegments) {
+              void pumpLog(update.logSegments);
             }
           },
           // A handful of failures in a row usually means the browser blocked
@@ -221,6 +253,9 @@ const BuildProgressDialog: React.FC<BuildProgressDialogProps> = ({
           onFetchError: (_error, consecutiveFailures) =>
             setIsStatusUnreachable(consecutiveFailures >= 3),
         });
+        // Before anything is decided about the build, so that a failure is
+        // shown with everything the compiler said rather than most of it.
+        await pumpLog(finalStatus.logSegments ?? 0);
         if (finalStatus.state === 'error') {
           setIsRetryable(false);
           setDidBuildFail(true);

--- a/src/firmware/buildStatus.test.ts
+++ b/src/firmware/buildStatus.test.ts
@@ -186,12 +186,14 @@ describe('parseBuildStatus', () => {
 
   it('keeps the build output printable', () => {
     // What a compiler writes: CRLF from the runner, a progress line rewritten
-    // with a carriage return, and colour codes the workflow did not strip.
+    // with a carriage return, and colour codes the workflow did not strip -
+    // including the sub-parameter form docker's buildx uses. Dropping the
+    // escape byte alone would leave `[1:2m` in the page as text.
     expect(
       cleanLogText(
-        'Compiling\r\n\u001b[31mERROR\u001b[0m failed\r  retrying\u0000\n'
+        'Compiling\r\n\u001b[31mERROR\u001b[0m \u001b[1:2mfailed\u001b[0m\r  retrying\u0000\n'
       )
-    ).toBe('Compiling\n[31mERROR[0m failed\n  retrying\n');
+    ).toBe('Compiling\nERROR failed\n  retrying\n');
   });
 
   it('keeps only the end of a segment too long to render', () => {

--- a/src/firmware/buildStatus.test.ts
+++ b/src/firmware/buildStatus.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import {
   BuildStatus,
   BuildTimeoutError,
+  appendLogText,
   buildLogSegmentUrl,
   buildStatusUrl,
   cleanLogText,
@@ -201,6 +202,26 @@ describe('parseBuildStatus', () => {
 
     expect(cleaned.length).toBe(200000);
     expect(cleaned.endsWith('last')).toBe(true);
+  });
+
+  it('keeps the accumulated output bounded, not just each segment', () => {
+    // Capping one segment leaves the sum of them unbounded, and it is the
+    // joined string the log view re-renders every time one arrives.
+    const joined = appendLogText(
+      `START${'x'.repeat(900000)}`,
+      `${'y'.repeat(200000)}end`
+    );
+
+    expect(joined.length).toBe(1000000);
+    // The end is what a running build is saying, and why a stopped one stopped.
+    expect(joined.endsWith('end')).toBe(true);
+    expect(joined.startsWith('START')).toBe(false);
+  });
+
+  it('joins segments unchanged while there is room', () => {
+    expect(appendLogText('Compiling\n', 'Linking\n')).toBe(
+      'Compiling\nLinking\n'
+    );
   });
 
   it('returns null for documents it does not understand', () => {

--- a/src/firmware/buildStatus.test.ts
+++ b/src/firmware/buildStatus.test.ts
@@ -142,6 +142,41 @@ describe('parseBuildStatus', () => {
     expect(status?.progress).toEqual({ completed: 1600, total: undefined });
   });
 
+  it('reads the tail of the build output', () => {
+    expect(
+      parseBuildStatus({ status: 'building', log: 'Compiling app\n' })?.log
+    ).toBe('Compiling app\n');
+    expect(
+      parseBuildStatus({ status: 'building', log: '' })?.log
+    ).toBeUndefined();
+    expect(
+      parseBuildStatus({ status: 'building', log: ' \n' })?.log
+    ).toBeUndefined();
+    expect(
+      parseBuildStatus({ status: 'building', log: 42 })?.log
+    ).toBeUndefined();
+  });
+
+  it('keeps the build output printable', () => {
+    const status = parseBuildStatus({
+      status: 'error',
+      // What a compiler writes: CRLF from the runner, a progress line rewritten
+      // with a carriage return, and the colour codes around the level.
+      log: 'Compiling\r\n\u001b[31mERROR\u001b[0m failed\r  retrying\u0000\n',
+    });
+
+    expect(status?.log).toBe('Compiling\n[31mERROR[0m failed\n  retrying\n');
+  });
+
+  it('keeps only the end of a build output that is too long to render', () => {
+    const log = `${'x'.repeat(50000)}last`;
+
+    const parsed = parseBuildStatus({ status: 'error', log })?.log ?? '';
+
+    expect(parsed.length).toBe(40000);
+    expect(parsed.endsWith('last')).toBe(true);
+  });
+
   it('returns null for documents it does not understand', () => {
     expect(parseBuildStatus(null)).toBeNull();
     expect(parseBuildStatus('building')).toBeNull();

--- a/src/firmware/buildStatus.test.ts
+++ b/src/firmware/buildStatus.test.ts
@@ -3,7 +3,10 @@ import path from 'path';
 import {
   BuildStatus,
   BuildTimeoutError,
+  buildLogSegmentUrl,
   buildStatusUrl,
+  cleanLogText,
+  fetchLogSegment,
   firmwareDownloadUrl,
   parseBuildStatus,
   pollBuildStatus,
@@ -33,6 +36,21 @@ describe('the object layout', () => {
     expect(firmwareDownloadUrl('a-build')).toMatch(
       new RegExp(
         `/firmware/a-build${escapeForRegExp(uploaded!.groups!.suffix)}$`
+      )
+    );
+  });
+
+  it('matches the key the build output segments are published to', () => {
+    // The sequence number is interpolated by the shell, so the key is matched
+    // as a literal part and the counter that follows it.
+    const published = repoFile('scripts', 'publish-build-log.sh').match(
+      /s3:\/\/\$\{S3_BUCKET\}\/firmware\/\$\{IDENTIFIER\}(?<suffix>[^"$]*)\$\{\w+\}"/
+    );
+
+    expect(published).not.toBeNull();
+    expect(buildLogSegmentUrl('a-build', 7)).toMatch(
+      new RegExp(
+        `/firmware/a-build${escapeForRegExp(published!.groups!.suffix)}7$`
       )
     );
   });
@@ -142,39 +160,45 @@ describe('parseBuildStatus', () => {
     expect(status?.progress).toEqual({ completed: 1600, total: undefined });
   });
 
-  it('reads the tail of the build output', () => {
+  it('reads how many build output segments exist', () => {
     expect(
-      parseBuildStatus({ status: 'building', log: 'Compiling app\n' })?.log
-    ).toBe('Compiling app\n');
+      parseBuildStatus({ status: 'building', log_segments: 12 })?.logSegments
+    ).toBe(12);
     expect(
-      parseBuildStatus({ status: 'building', log: '' })?.log
+      parseBuildStatus({ status: 'building' })?.logSegments
     ).toBeUndefined();
     expect(
-      parseBuildStatus({ status: 'building', log: ' \n' })?.log
+      parseBuildStatus({ status: 'building', log_segments: 0 })?.logSegments
     ).toBeUndefined();
     expect(
-      parseBuildStatus({ status: 'building', log: 42 })?.log
+      parseBuildStatus({ status: 'building', log_segments: 1.5 })?.logSegments
     ).toBeUndefined();
+    expect(
+      parseBuildStatus({ status: 'building', log_segments: '12' })?.logSegments
+    ).toBeUndefined();
+  });
+
+  it('will not be sent fetching segments without end', () => {
+    expect(
+      parseBuildStatus({ status: 'building', log_segments: 1e9 })?.logSegments
+    ).toBe(500);
   });
 
   it('keeps the build output printable', () => {
-    const status = parseBuildStatus({
-      status: 'error',
-      // What a compiler writes: CRLF from the runner, a progress line rewritten
-      // with a carriage return, and the colour codes around the level.
-      log: 'Compiling\r\n\u001b[31mERROR\u001b[0m failed\r  retrying\u0000\n',
-    });
-
-    expect(status?.log).toBe('Compiling\n[31mERROR[0m failed\n  retrying\n');
+    // What a compiler writes: CRLF from the runner, a progress line rewritten
+    // with a carriage return, and colour codes the workflow did not strip.
+    expect(
+      cleanLogText(
+        'Compiling\r\n\u001b[31mERROR\u001b[0m failed\r  retrying\u0000\n'
+      )
+    ).toBe('Compiling\n[31mERROR[0m failed\n  retrying\n');
   });
 
-  it('keeps only the end of a build output that is too long to render', () => {
-    const log = `${'x'.repeat(50000)}last`;
+  it('keeps only the end of a segment too long to render', () => {
+    const cleaned = cleanLogText(`${'x'.repeat(250000)}last`);
 
-    const parsed = parseBuildStatus({ status: 'error', log })?.log ?? '';
-
-    expect(parsed.length).toBe(40000);
-    expect(parsed.endsWith('last')).toBe(true);
+    expect(cleaned.length).toBe(200000);
+    expect(cleaned.endsWith('last')).toBe(true);
   });
 
   it('returns null for documents it does not understand', () => {
@@ -295,5 +319,43 @@ describe('pollBuildStatus', () => {
         sleep: noSleep,
       })
     ).rejects.toBeInstanceOf(BuildTimeoutError);
+  });
+});
+
+describe('fetchLogSegment', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const respond = (response: Partial<Response>) => {
+    const spy = jest.fn().mockResolvedValue(response as Response);
+    global.fetch = spy as unknown as typeof fetch;
+    return spy;
+  };
+
+  it('reads a segment and cleans what the compiler wrote', async () => {
+    const fetchSpy = respond({
+      ok: true,
+      text: async () => 'Compiling\r\napp\u0000\n',
+    });
+
+    await expect(fetchLogSegment('a-build', 3)).resolves.toBe(
+      'Compiling\napp\n'
+    );
+    expect(fetchSpy.mock.calls[0][0]).toBe(buildLogSegmentUrl('a-build', 3));
+  });
+
+  it('returns null for a segment that is not published yet', async () => {
+    respond({ ok: false, status: 404 });
+
+    await expect(fetchLogSegment('a-build', 3)).resolves.toBeNull();
+  });
+
+  it('returns an empty string for a segment with nothing in it', async () => {
+    respond({ ok: true, text: async () => '' });
+
+    await expect(fetchLogSegment('a-build', 0)).resolves.toBe('');
   });
 });

--- a/src/firmware/buildStatus.ts
+++ b/src/firmware/buildStatus.ts
@@ -18,6 +18,15 @@ export const firmwareDownloadUrl = (identifier: string) =>
 export const buildStatusUrl = (identifier: string) =>
   objectUrl(`firmware/${identifier}.status.json`);
 
+/**
+ * One slice of the build output. Segments are immutable and numbered from
+ * zero; the status document says how many of them exist. S3 cannot append to
+ * an object, so a growing log has to be published as a run of objects like
+ * this - see scripts/publish-build-log.sh.
+ */
+export const buildLogSegmentUrl = (identifier: string, sequence: number) =>
+  objectUrl(`firmware/${identifier}.log.${sequence}`);
+
 export const buildListUrl = 'https://github.com/tomquist/esphome-b2500/actions';
 
 export type BuildState = 'building' | 'success' | 'error';
@@ -41,10 +50,10 @@ export interface BuildStatus {
   /** Compile units finished so far, reported while compiling. */
   progress?: BuildProgress;
   /**
-   * Tail of the build output. Present while the workflow can read its own job
-   * log, and on a failed build it ends at whatever stopped it.
+   * How many build output segments have been published. Absent while the
+   * workflow has not managed to read its own job log.
    */
-  log?: string;
+  logSegments?: number;
   firmwareUrl?: string;
   /** Name of the firmware directory inside the ZIP, e.g. `b2500-esp32`. */
   firmwareName?: string;
@@ -115,30 +124,35 @@ const optionalCount = (value: unknown): number | undefined =>
     : undefined;
 
 /**
- * How much of the build output to keep. The workflow publishes far less than
- * this; the cap is here so a status document that ever said otherwise cannot
- * hand the log view something too big to render.
+ * Caps on what the build output can make the page do. The workflow publishes
+ * far less than either; they are here so a status document that ever said
+ * otherwise cannot send the page fetching forever or hand the log view
+ * something too big to render.
  */
-const MAX_LOG_CHARS = 40000;
+const MAX_LOG_SEGMENTS = 500;
+const MAX_SEGMENT_CHARS = 200000;
 
 /**
- * The log is whatever the compiler wrote, so it arrives with terminal escapes
- * and stray control bytes in it. React renders it as text either way - this is
+ * Segment bodies are whatever the compiler wrote, so they arrive with stray
+ * control bytes in them. React renders the result as text either way - this is
  * so what the user sees is what the build printed, rather than a `\r` eating
  * the line it was on.
  */
-const parseLog = (value: unknown): string | undefined => {
-  const raw = optionalString(value);
-  if (!raw) {
-    return undefined;
-  }
+export const cleanLogText = (raw: string): string => {
   const text = raw
     .replace(/\r\n?/g, '\n')
     // eslint-disable-next-line no-control-regex
     .replace(/[\u0000-\u0008\u000b-\u001f\u007f]/g, '');
-  const trimmed =
-    text.length > MAX_LOG_CHARS ? text.slice(-MAX_LOG_CHARS) : text;
-  return trimmed.trim().length > 0 ? trimmed : undefined;
+  return text.length > MAX_SEGMENT_CHARS
+    ? text.slice(-MAX_SEGMENT_CHARS)
+    : text;
+};
+
+const parseSegmentCount = (value: unknown): number | undefined => {
+  const count = optionalCount(value);
+  return count !== undefined && Number.isInteger(count) && count > 0
+    ? Math.min(count, MAX_LOG_SEGMENTS)
+    : undefined;
 };
 
 const parseStep = (value: unknown): BuildStep | undefined => {
@@ -180,11 +194,32 @@ export const parseBuildStatus = (raw: unknown): BuildStatus | null => {
     message: optionalString(record.message),
     step: parseStep(record.step),
     progress: parseProgress(record.progress),
-    log: parseLog(record.log),
+    logSegments: parseSegmentCount(record.log_segments),
     firmwareUrl: trustedUrl(record.firmware_url, bucketOrigins()),
     firmwareName: optionalString(record.firmware_name),
     esphomeVersion: optionalString(record.esphome_version),
   };
+};
+
+/**
+ * Reads one segment of the build output. Resolves with `null` when it is not
+ * published yet, which is how a page that read a segment count from a status
+ * document written moments ago tells "not there" from "not any more".
+ */
+export const fetchLogSegment = async (
+  identifier: string,
+  sequence: number,
+  signal?: AbortSignal
+): Promise<string | null> => {
+  // No `no-store` here, unlike the status document: a segment never changes
+  // once published, so a reload may reuse whatever the browser kept.
+  const response = await fetch(buildLogSegmentUrl(identifier, sequence), {
+    signal,
+  });
+  if (!response.ok) {
+    return null;
+  }
+  return cleanLogText(await response.text());
 };
 
 export class BuildTimeoutError extends Error {

--- a/src/firmware/buildStatus.ts
+++ b/src/firmware/buildStatus.ts
@@ -137,10 +137,19 @@ const MAX_SEGMENT_CHARS = 200000;
  * control bytes in them. React renders the result as text either way - this is
  * so what the user sees is what the build printed, rather than a `\r` eating
  * the line it was on.
+ *
+ * The workflow strips terminal escapes before publishing, so the CSI pass here
+ * is the second of two. It earns its place by being the last one: dropping the
+ * escape byte alone would leave `[1:2m` sitting in the page as text, and this
+ * is the only point that sees what a segment actually contains.
  */
 export const cleanLogText = (raw: string): string => {
   const text = raw
     .replace(/\r\n?/g, '\n')
+    // Parameter bytes, then intermediates, then the final byte: the whole CSI
+    // form rather than the colour codes alone.
+    // eslint-disable-next-line no-control-regex
+    .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, '')
     // eslint-disable-next-line no-control-regex
     .replace(/[\u0000-\u0008\u000b-\u001f\u007f]/g, '');
   return text.length > MAX_SEGMENT_CHARS
@@ -148,6 +157,7 @@ export const cleanLogText = (raw: string): string => {
     : text;
 };
 
+/** How many segments the status document says exist, clamped to the cap. */
 const parseSegmentCount = (value: unknown): number | undefined => {
   const count = optionalCount(value);
   return count !== undefined && Number.isInteger(count) && count > 0

--- a/src/firmware/buildStatus.ts
+++ b/src/firmware/buildStatus.ts
@@ -131,6 +131,12 @@ const optionalCount = (value: unknown): number | undefined =>
  */
 const MAX_LOG_SEGMENTS = 500;
 const MAX_SEGMENT_CHARS = 200000;
+/**
+ * And on the segments once joined: capping each one still leaves the sum of
+ * them unbounded, and it is the accumulated string that the log view re-renders
+ * every time a segment arrives.
+ */
+const MAX_LOG_CHARS = 1000000;
 
 /**
  * Segment bodies are whatever the compiler wrote, so they arrive with stray
@@ -155,6 +161,17 @@ export const cleanLogText = (raw: string): string => {
   return text.length > MAX_SEGMENT_CHARS
     ? text.slice(-MAX_SEGMENT_CHARS)
     : text;
+};
+
+/** How many segments the status document says exist, clamped to the cap. */
+/**
+ * Adds a segment to what the page has already read, keeping the end: the tail
+ * is where a build that is still running says what it is doing, and where one
+ * that stopped says why.
+ */
+export const appendLogText = (previous: string, segment: string): string => {
+  const joined = previous + segment;
+  return joined.length > MAX_LOG_CHARS ? joined.slice(-MAX_LOG_CHARS) : joined;
 };
 
 /** How many segments the status document says exist, clamped to the cap. */

--- a/src/firmware/buildStatus.ts
+++ b/src/firmware/buildStatus.ts
@@ -40,6 +40,11 @@ export interface BuildStatus {
   step?: BuildStep;
   /** Compile units finished so far, reported while compiling. */
   progress?: BuildProgress;
+  /**
+   * Tail of the build output. Present while the workflow can read its own job
+   * log, and on a failed build it ends at whatever stopped it.
+   */
+  log?: string;
   firmwareUrl?: string;
   /** Name of the firmware directory inside the ZIP, e.g. `b2500-esp32`. */
   firmwareName?: string;
@@ -109,6 +114,33 @@ const optionalCount = (value: unknown): number | undefined =>
     ? value
     : undefined;
 
+/**
+ * How much of the build output to keep. The workflow publishes far less than
+ * this; the cap is here so a status document that ever said otherwise cannot
+ * hand the log view something too big to render.
+ */
+const MAX_LOG_CHARS = 40000;
+
+/**
+ * The log is whatever the compiler wrote, so it arrives with terminal escapes
+ * and stray control bytes in it. React renders it as text either way - this is
+ * so what the user sees is what the build printed, rather than a `\r` eating
+ * the line it was on.
+ */
+const parseLog = (value: unknown): string | undefined => {
+  const raw = optionalString(value);
+  if (!raw) {
+    return undefined;
+  }
+  const text = raw
+    .replace(/\r\n?/g, '\n')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u0008\u000b-\u001f\u007f]/g, '');
+  const trimmed =
+    text.length > MAX_LOG_CHARS ? text.slice(-MAX_LOG_CHARS) : text;
+  return trimmed.trim().length > 0 ? trimmed : undefined;
+};
+
 const parseStep = (value: unknown): BuildStep | undefined => {
   const step = optionalString(value)?.toLowerCase();
   return STEPS.find((known) => known === step);
@@ -148,6 +180,7 @@ export const parseBuildStatus = (raw: unknown): BuildStatus | null => {
     message: optionalString(record.message),
     step: parseStep(record.step),
     progress: parseProgress(record.progress),
+    log: parseLog(record.log),
     firmwareUrl: trustedUrl(record.firmware_url, bucketOrigins()),
     firmwareName: optionalString(record.firmware_name),
     esphomeVersion: optionalString(record.esphome_version),
@@ -269,7 +302,7 @@ export const pollBuildStatus = async ({
   signal,
   onStatus,
   onFetchError,
-  intervalMs = 5000,
+  intervalMs = 3000,
   timeoutMs = 30 * 60 * 1000,
   requestTimeoutMs = 30000,
   fetchStatus = fetchBuildStatus,


### PR DESCRIPTION
## Summary

This change enables the web builder to display the compiler's output in real-time as the build progresses, rather than only showing it after the build completes. The build workflow now publishes the compiler output as immutable segments to S3, and the web builder fetches and displays these segments as they become available.

## Key Changes

- **Build output publishing**: Added `scripts/publish-build-log.sh` to publish the compiler's output as append-only segments (`firmware/<identifier>.log.0`, `.log.1`, etc.) to S3. Since S3 doesn't support appending to objects, the log is split into immutable segments, each containing only the bytes that appeared since the last segment.

- **Job log fetching**: Added `scripts/fetch-job-log.sh` to read the build job's own log from the GitHub Actions API, clean it (removing timestamps, terminal escapes, and runner markers), and make it available for publishing. This is the only way to access the compiler's output since it runs inside a third-party action.

- **Progress watcher enhancement**: Modified `scripts/watch-build-progress.sh` to periodically call `publish-build-log.sh` alongside the existing status publishing, with a slower interval (10s vs 5s) to respect GitHub API rate limits.

- **Status document updates**: Extended `BuildStatus` to include a `logSegments` field indicating how many output segments have been published, allowing the web builder to know which segments to fetch.

- **Web builder integration**: Modified `BuildProgressDialog` to:
  - Fetch log segments as they're announced in the status document
  - Display them in a scrollable log view that auto-scrolls to the bottom unless the user has scrolled up
  - Clean segment text to remove control characters and cap segment size to 200KB for rendering performance

- **Log text cleaning**: Added `cleanLogText()` utility to sanitize compiler output by removing CRLF sequences, null bytes, and other control characters while preserving the visual output.

- **Comprehensive test coverage**: Added test suites for both `publish-build-log.sh` and `fetch-job-log.sh` covering edge cases like partial reads, upload failures, log truncation, and API unavailability.

- **Workflow permissions**: Updated GitHub Actions workflow to request `actions: read` permission so the build can read its own job log from the API.

## Implementation Details

- **Correctness guarantees**: The publishing scheme ensures every byte is uploaded exactly once, in order. The published bytes are compared against new reads to detect if the log was truncated or restarted, preventing corruption of the displayed output.

- **Best-effort design**: Log publishing is entirely optional—builds that cannot read their own log still report progress and failure, just without the output. Failed API calls don't fail the build step.

- **Rate limiting**: Log fetching uses a 10-second interval (vs 5-second for progress) to stay within GitHub API limits across multiple concurrent builds.

- **Segment caching**: The web builder downloads each segment exactly once and accumulates them, so if the API becomes unavailable mid-build, previously fetched output is retained.

https://claude.ai/code/session_01KNoarAK2zgJZG7crJUt3TH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build progress now includes live compiler output while firmware builds are running.
  * Build logs load incrementally, remain available after failures, and support easier review of error details.
  * Progress updates now reflect both compiled firmware objects and available build-log output.

* **Bug Fixes**
  * Improved log publishing helps prevent missing, incomplete, or duplicated output during long-running builds.
  * Terminal formatting artifacts are now removed from displayed build logs.

* **Documentation**
  * Updated firmware storage documentation to describe build status and segmented log output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->